### PR TITLE
fix(just) : check pnpm version

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,15 @@ doctor:
     check docker      "docker --version"      "https://docs.docker.com/get-docker"
     echo
     [ $missing -eq 0 ] || { echo "  Install what's missing, then run just doctor again."; exit 1; }
+    # web/package.json pins a pnpm version. Plain pnpm switches to it on its own; under
+    # corepack it can't, and `just setup` dies on a version mismatch instead.
+    want=$(sed -n 's/.*"packageManager": *"pnpm@\([^"]*\)".*/\1/p' web/package.json)
+    have=$(pnpm --version 2>/dev/null)
+    if [ -n "$want" ] && [ "$want" != "$have" ]; then
+        printf '  note     %-12s v%s here, web/package.json pins %s\n' pnpm "$have" "$want"
+        echo "           Fine unless setup complains. If it does: corepack prepare pnpm@$want --activate"
+        echo
+    fi
     echo "  Everything's here. Run: just setup"
 
 # Install dependencies. Once, after cloning.

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "firetower-web",
   "version": "0.14.0",
   "private": true,
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@11.23.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
When I followed the contributing instructions, it failed

```
just doctor     # checks you have the tools
OK

just setup      # installs dependencies, once

[ERROR] This project is configured to use 11.21.0 of pnpm. Your current pnpm is v11.23.0
  Corepack invoked pnpm with this version, and pnpm does not switch versions when running under corepack.
  Align the "packageManager" field in package.json with "devEngines.packageManager", or invoke pnpm directly (without corepack) so it can switch versions automatically.
  If you want to bypass this version check, you can set the "pmOnFail" configuration to "warn" or "ignore" (e.g. via --pm-on-fail=ignore). If using "devEngines.packageManager", you can set its "onFail" to "warn" or "ignore"
  error: recipe setup failed with exit code 1
```

The web/package.json version of pnpm is set to 11.21.0 but brew installed latest 11.23.0.
So just doctor must check pnpm too ;)
