### PR TITLE
feat: reauthorize GitHub to add organizations and repositories

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5843,6 +5843,13 @@
           "configured"
         ],
         "properties": {
+          "clientId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The identifier being authorized against, when there is one.\n\nSent so the interface can link to the page on the host where this\napplication's access is reviewed — the only place an organization that\nrestricts third-party applications can be requested after the fact, and\nthe address of it contains the client id. Public by design: a\ndevice-flow application has no paired secret."
+          },
           "configured": {
             "type": "boolean",
             "description": "False when nobody has registered an application for this build, which is\na setup problem rather than something the person using it did wrong."

--- a/crates/ft-server/src/api/providers.rs
+++ b/crates/ft-server/src/api/providers.rs
@@ -243,6 +243,7 @@ pub(super) async fn list_providers(
 
     let mut out = Vec::new();
     for p in providers::PROVIDERS {
+        let client_id = providers::client_id(&state.accounts, p.id).await;
         out.push(ProviderStatus {
             id: p.id.to_string(),
             label: p.label.to_string(),
@@ -250,10 +251,11 @@ pub(super) async fn list_providers(
             // operating system may put behind a prompt, and this endpoint only
             // renders a screen.
             connected: state.vault.holds(Key::of(vault::GIT, p.id, owner)).await?,
-            configured: providers::client_id(&state.accounts, p.id).await.is_some(),
+            configured: client_id.is_some(),
             pending: pending
                 .get(&format!("{}:{owner}", p.id))
                 .map(|p| p.auth.clone()),
+            client_id,
         });
     }
     Ok(Json(out))
@@ -263,6 +265,15 @@ pub(super) async fn list_providers(
 ///
 /// Returns immediately with the code to show. The waiting happens here rather
 /// than in the browser so that closing the tab doesn't abandon it.
+///
+/// Asked again by somebody already connected, and deliberately so: the host's
+/// approval screen is where organizations are granted, and it is shown once
+/// per authorization. Somebody who skipped an organization the first time has
+/// nowhere else to go. Nothing is given up by trying — the vault is written
+/// only where the poll below approves, so a re-authorization that is abandoned
+/// or declined leaves the token that is already there untouched, and the
+/// insert at the end replaces any earlier attempt, whose `Drop` stops its
+/// poller.
 #[utoipa::path(
     post, path = "/api/v1/providers/{id}/authorize", tag = "providers",
     params(("id" = String, Path, description = "Provider id")),

--- a/crates/ft-server/src/providers.rs
+++ b/crates/ft-server/src/providers.rs
@@ -122,6 +122,14 @@ pub struct ProviderStatus {
     pub configured: bool,
     /// Set while an authorization is in flight.
     pub pending: Option<PendingAuth>,
+    /// The identifier being authorized against, when there is one.
+    ///
+    /// Sent so the interface can link to the page on the host where this
+    /// application's access is reviewed — the only place an organization that
+    /// restricts third-party applications can be requested after the fact, and
+    /// the address of it contains the client id. Public by design: a
+    /// device-flow application has no paired secret.
+    pub client_id: Option<String>,
 }
 
 /// A device authorization waiting for someone to approve it in a browser.
@@ -158,6 +166,32 @@ mod tests {
             client_id(&accounts, "github").await.as_deref(),
             Some("Ov23liSTORED")
         );
+    }
+
+    /// The interface builds the address of the host's own access page out of
+    /// this, and cannot ask anywhere else for it. A rename here breaks that
+    /// link silently, which is the kind of thing this pins.
+    #[test]
+    fn a_status_carries_the_identifier_it_authorizes_against() {
+        let status = ProviderStatus {
+            id: "github".into(),
+            label: "GitHub".into(),
+            connected: true,
+            configured: true,
+            pending: None,
+            client_id: Some("Ov23liEXAMPLE".into()),
+        };
+
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["clientId"], "Ov23liEXAMPLE");
+
+        // Nothing registered is `null` rather than an empty string, which
+        // would build an address to a page that does not exist.
+        let none = ProviderStatus {
+            client_id: None,
+            ..status
+        };
+        assert!(serde_json::to_value(&none).unwrap()["clientId"].is_null());
     }
 
     #[test]

--- a/web/app/repos/page.tsx
+++ b/web/app/repos/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { GitIdentity } from "@/components/GitIdentity";
+import { GitHubAccess } from "@/components/GitHubAccess";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useListRepos,
@@ -57,6 +58,10 @@ export default function Repos() {
         {/* Here rather than on an account screen: this belongs to the git host,
             not to your Firetower login. Signing in and being credited for a
             commit are facts about two different accounts. */}
+        {/* What the host shares with us, and the way back to that choice.
+            Above the identity because it is the wider fact: what can be seen
+            at all comes before what a commit is signed with. */}
+        <GitHubAccess provider="github" label="GitHub" />
         <GitIdentity provider="github" label="GitHub" />
       </header>
 

--- a/web/components/ConnectAgent.tsx
+++ b/web/components/ConnectAgent.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/src/api/generated/agents/agents";
 import { AgentMode, type AgentView, type AgentOnHost } from "@/src/api/generated/model";
 import { ApiError } from "@/src/api/http";
-import { CodeToType, Spinner } from "./ConnectRepo";
+import { CodeToType, Spinner } from "./Modal";
 import { Install } from "./InstallAgent";
 
 /**

--- a/web/components/ConnectRepo.tsx
+++ b/web/components/ConnectRepo.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Check, LoaderCircle } from "lucide-react";
+import { Check } from "lucide-react";
 import { Icon } from "@/components/ui";
 import { useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Modal, Foot, Go, Quiet } from "./Modal";
+import { Modal, Foot, Go, Quiet, DeviceCode, Failure, Spinner } from "./Modal";
 import { ClientIdForm } from "./SetupAccount";
 import {
   useListProviders,
@@ -17,7 +17,7 @@ import {
   getListReposQueryKey,
 } from "@/src/api/generated/repos/repos";
 import type { ProviderStatus, RemoteRepo } from "@/src/api/generated/model";
-import { ApiError } from "@/src/api/http";
+import { Access } from "./GitHubAccess";
 
 /**
  * Authorize once, pick from what comes back.
@@ -28,6 +28,8 @@ import { ApiError } from "@/src/api/http";
  */
 export function ConnectRepo({ onClose }: { onClose: () => void }) {
   const [manual, setManual] = useState(false);
+  /** Widening what the authorization covers, from inside the picker. */
+  const [widening, setWidening] = useState(false);
 
   const [started, setStarted] = useState(false);
 
@@ -44,6 +46,15 @@ export function ConnectRepo({ onClose }: { onClose: () => void }) {
     <Modal title="Connect a repository" onClose={onClose} wide>
       {manual ? (
         <PasteRemote onBack={() => setManual(false)} onClose={onClose} />
+      ) : widening && provider ? (
+        // In this window rather than another: somebody who came to pick a
+        // repository and could not find it should get the picker back, with
+        // the list asked for again.
+        <Access
+          provider={provider}
+          onDone={() => setWidening(false)}
+          backLabel="Back to the list"
+        />
       ) : !provider ? (
         <p className="py-6 text-center text-ui text-mute">Looking…</p>
       ) : !provider.configured ? (
@@ -55,7 +66,12 @@ export function ConnectRepo({ onClose }: { onClose: () => void }) {
           onManual={() => setManual(true)}
         />
       ) : (
-        <Pick provider={provider} onManual={() => setManual(true)} onClose={onClose} />
+        <Pick
+          provider={provider}
+          onManual={() => setManual(true)}
+          onWiden={() => setWidening(true)}
+          onClose={onClose}
+        />
       )}
     </Modal>
   );
@@ -128,53 +144,11 @@ function Authorize({
 
   return (
     <>
-      <p className="text-ui text-dim">
-        A tab opened at{" "}
-        <a
-          href={pending.verificationUri}
-          target="_blank"
-          rel="noopener"
-          className="text-dim underline underline-offset-2 transition-colors hover:text-bone"
-        >
-          {pending.verificationUri.replace(/^https?:\/\//, "")}
-        </a>
-        . Enter this code:
-      </p>
-
-      <CodeToType code={pending.userCode} />
-
-      <p className="mt-4 flex items-center gap-2 text-meta text-mute">
-        <Spinner />
-        Waiting for you to approve it…
-      </p>
-
+      <DeviceCode pending={pending} />
       <Foot>
         <Quiet onClick={onManual}>Paste a URL instead</Quiet>
       </Foot>
     </>
-  );
-}
-
-/** Shown, not clicked — so it needs to be readable and copyable. */
-export function CodeToType({ code }: { code: string }) {
-  const [copied, setCopied] = useState(false);
-
-  return (
-    <div className="mt-3 flex items-center gap-3">
-      <code className="rounded-md border border-line bg-raise px-4 py-2.5 font-mono text-display tracking-[0.18em] text-bone">
-        {code}
-      </code>
-      <button
-        onClick={() => {
-          navigator.clipboard.writeText(code);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1600);
-        }}
-        className="text-meta text-mute transition-colors hover:text-text"
-      >
-        {copied ? "Copied" : "Copy"}
-      </button>
-    </div>
   );
 }
 
@@ -183,10 +157,12 @@ export function CodeToType({ code }: { code: string }) {
 function Pick({
   provider,
   onManual,
+  onWiden,
   onClose,
 }: {
   provider: ProviderStatus;
   onManual: () => void;
+  onWiden: () => void;
   onClose: () => void;
 }) {
   const [q, setQ] = useState("");
@@ -267,6 +243,18 @@ function Pick({
         </Go>
         <Quiet onClick={onManual}>Paste a URL instead</Quiet>
       </Foot>
+
+      {/* Said here because this is where it is felt: the list is what somebody
+          is staring at when they notice their organization is not in it. */}
+      <p className="mt-3 text-meta text-mute">
+        Missing one?{" "}
+        <button
+          onClick={onWiden}
+          className="text-dim underline underline-offset-2 transition-colors hover:text-bone"
+        >
+          Add an organization
+        </button>
+      </p>
     </>
   );
 }
@@ -414,28 +402,5 @@ function NotConfigured({
         <Go onClick={onManual}>Paste a URL instead</Go>
       </Foot>
     </>
-  );
-}
-
-/* ── shared ────────────────────────────────────────────────────────── */
-
-/**
- * The server writes these messages because only it knows which of several
- * things went wrong. Repeating them verbatim beats a generic line here.
- */
-function Failure({ error }: { error: unknown }) {
-  const message =
-    error instanceof ApiError ? error.message : "Something went wrong. Try again.";
-
-  return (
-    <div className="mt-4 rounded-md border border-line bg-raise px-3.5 py-2.5">
-      <p className="text-meta leading-[1.55] text-bone">{message}</p>
-    </div>
-  );
-}
-
-export function Spinner() {
-  return (
-    <Icon of={LoaderCircle} size={12} className="animate-spin" />
   );
 }

--- a/web/components/GitHubAccess.tsx
+++ b/web/components/GitHubAccess.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUpRight, Check } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Icon } from "@/components/ui";
+import { Modal, Foot, Go, Quiet, DeviceCode, Failure } from "./Modal";
+import {
+  listProviders,
+  listProviderRepos,
+  useListProviders,
+  useAuthorizeProvider,
+  useListProviderRepos,
+  getListProviderReposQueryKey,
+} from "@/src/api/generated/providers/providers";
+import type { PendingAuth, ProviderStatus, RemoteRepo } from "@/src/api/generated/model";
+
+/**
+ * Widening what Firetower can see on a git host.
+ *
+ * A token covers the organizations you granted on the host's approval screen,
+ * and that screen is shown once — when you first authorize. Skip an
+ * organization there, or join one afterwards, and there has never been a way
+ * back to it from here: the picker simply doesn't list those repositories and
+ * nothing says why.
+ *
+ * Authorizing again is the way back, because the approval screen is shown
+ * every time and lists every organization with Grant or Request beside it.
+ * Nothing is risked by trying — the control plane only replaces a token when a
+ * new authorization is approved.
+ */
+
+/* ── the facts, as functions ───────────────────────────────────────── */
+
+/** `acme` out of `acme/backend`, each one once, in the order first seen. */
+export function ownersOf(repos: RemoteRepo[]): string[] {
+  const seen: string[] = [];
+  for (const repo of repos) {
+    const owner = repo.slug.split("/")[0];
+    if (owner && !seen.includes(owner)) seen.push(owner);
+  }
+  return seen;
+}
+
+/**
+ * Where this application's access is reviewed on the host.
+ *
+ * The second half of the answer, and the one authorizing again cannot give:
+ * an organization that restricts third-party applications stays dark until an
+ * owner approves the request, and this is the page the request is made and
+ * tracked on.
+ */
+export function accessUrl(clientId: string | null | undefined): string | null {
+  const id = clientId?.trim();
+  return id ? `https://github.com/settings/connections/applications/${id}` : null;
+}
+
+/** What a re-authorization actually bought, in a sentence. */
+export function whatChanged(before: RemoteRepo[], after: RemoteRepo[]): string {
+  const had = new Set(before.map((r) => r.slug));
+  const gained = after.filter((r) => !had.has(r.slug));
+  const owners = ownersOf(gained).filter((o) => !ownersOf(before).includes(o));
+
+  if (gained.length === 0) {
+    // Said plainly rather than dressed up as success. This is the common end
+    // of the road for a restricted organization: the request is in, and
+    // somebody with admin rights has to say yes before anything changes.
+    return (
+      "Nothing new is visible. An organization that restricts third-party " +
+      "applications stays hidden until an owner approves the request."
+    );
+  }
+
+  const one = gained.length === 1;
+  const repos = `${gained.length} more ${one ? "repository is" : "repositories are"}`;
+  if (owners.length === 0) return `${repos} visible now.`;
+  const named =
+    owners.length === 1 ? owners[0] : `${owners.slice(0, -1).join(", ")} and ${owners.at(-1)}`;
+  return `${repos} visible now, from ${named}.`;
+}
+
+/** How much a token can see, for the line on the settings page. */
+export function reach(repos: RemoteRepo[]): string {
+  const owners = ownersOf(repos).length;
+  const r = `${repos.length} ${repos.length === 1 ? "repository" : "repositories"}`;
+  const o = `${owners} ${owners === 1 ? "account or organization" : "accounts and organizations"}`;
+  return `${r} across ${o}`;
+}
+
+/**
+ * Wait until the authorization we started is no longer in flight.
+ *
+ * Watched through `pending` rather than through `connected`, which never
+ * changes here — the token being replaced is one that already works. The
+ * control plane records the authorization before it answers the request that
+ * started it, so the first look either sees it or sees an attempt that is
+ * already over, and either way its disappearance is the end.
+ *
+ * Approved, declined and expired all end the same way on purpose. Which one it
+ * was is answered by what can be seen afterwards, which is the only answer
+ * worth showing anybody.
+ */
+async function settled(id: string): Promise<void> {
+  // A device code lasts about a quarter of an hour and the control plane drops
+  // the attempt when it expires, so this ends on its own. The cap is there for
+  // the case where nothing ever answers, not as the normal way out.
+  for (let asked = 0; asked < 600; asked++) {
+    await new Promise((wake) => setTimeout(wake, 2000));
+    const still = await listProviders()
+      .then((all) => all.find((p) => p.id === id)?.pending != null)
+      .catch(() => true); // A blip is not an answer. Keep waiting.
+    if (!still) return;
+  }
+}
+
+/* ── the panel on the repositories page ────────────────────────────── */
+
+/**
+ * On the repositories page because that is where somebody notices the gap —
+ * they came to connect a repository and it isn't in the list.
+ */
+export function GitHubAccess({ provider: id, label }: { provider: string; label: string }) {
+  const [managing, setManaging] = useState(false);
+  const { data: providers = [] } = useListProviders();
+  const provider = providers.find((p) => p.id === id);
+
+  // Nothing to widen before there is something to widen: the connect flow
+  // covers the first authorization, and saying this twice would be noise.
+  const connected = provider?.connected ?? false;
+  const { data: repos = [] } = useListProviderRepos(id, { query: { enabled: connected } });
+
+  if (!provider || !connected) return null;
+
+  return (
+    <div className="panel mt-2.5 px-4 py-3.5">
+      <div className="flex items-baseline gap-3">
+        <span className="eyebrow">{label} access</span>
+        <span className="font-mono text-meta text-mute">connected</span>
+        <button
+          onClick={() => setManaging(true)}
+          className="ml-auto text-meta text-mute transition-colors hover:text-bone"
+        >
+          Manage
+        </button>
+      </div>
+
+      <p className="mt-1.5 text-meta text-dim">
+        Firetower can see {reach(repos)}
+        {repos.length > 0 && (
+          <span className="text-mute"> — {ownersOf(repos).join(" · ")}</span>
+        )}
+        .
+      </p>
+      <p className="mt-1 text-meta text-mute">
+        Missing an organization? {label} asks which ones to share when you authorize,
+        and owners can restrict theirs.
+      </p>
+
+      {managing && <ManageAccess provider={provider} onClose={() => setManaging(false)} />}
+    </div>
+  );
+}
+
+/** The same thing as its own window, for the settings page. */
+function ManageAccess({ provider, onClose }: { provider: ProviderStatus; onClose: () => void }) {
+  return (
+    <Modal title={`${provider.label} access`} onClose={onClose} wide>
+      <Access provider={provider} onDone={onClose} />
+    </Modal>
+  );
+}
+
+/* ── the step itself, shared with the connect flow ─────────────────── */
+
+/**
+ * Explain, re-authorize, then say what changed.
+ *
+ * A step rather than a window so the connect flow can show it in the one it
+ * already has: somebody who came to pick a repository and could not find it
+ * should not lose the picker to fix that.
+ */
+export function Access({
+  provider,
+  onDone,
+  backLabel,
+}: {
+  provider: ProviderStatus;
+  onDone: () => void;
+  backLabel?: string;
+}) {
+  const cache = useQueryClient();
+  const { data: repos = [] } = useListProviderRepos(provider.id);
+  const authorize = useAuthorizeProvider();
+
+  /** The wait, once one is under way, and what it ended up buying. */
+  const [waiting, setWaiting] = useState<PendingAuth | null>(null);
+  const [outcome, setOutcome] = useState<string | null>(null);
+
+  const start = () => {
+    // Compared against once it is over: a grant that went through changes
+    // this, and a request still waiting on an owner does not.
+    const had = repos;
+    setOutcome(null);
+    authorize.mutate(
+      { id: provider.id },
+      {
+        onSuccess: async (auth) => {
+          // Opened from the click that asked for it, which is the only way
+          // browsers allow.
+          window.open(auth.verificationUri, "_blank", "noopener");
+          setWaiting(auth);
+          await settled(provider.id);
+          setWaiting(null);
+          // The panel behind this window counts the same repositories, so the
+          // cached list has to go whether or not anything changed.
+          await cache.invalidateQueries({ queryKey: getListProviderReposQueryKey(provider.id) });
+          setOutcome(whatChanged(had, await listProviderRepos(provider.id).catch(() => had)));
+        },
+      },
+    );
+  };
+
+  if (waiting) {
+    return (
+      <DeviceCode
+        pending={waiting}
+        note={`On that screen, grant every organization you want Firetower to clone from. Ones you skip stay hidden, and one an owner has to approve stays hidden until they do.`}
+      />
+    );
+  }
+
+  if (outcome) {
+    return (
+      <>
+        <p className="flex items-start gap-2.5 text-ui leading-[1.6] text-dim">
+          <span className="mt-[5px]">
+            <Icon of={Check} size={12} className="text-sage" />
+          </span>
+          {outcome}
+        </p>
+        <p className="mt-3 text-meta text-mute">Firetower can now see {reach(repos)}.</p>
+        <Foot>
+          <Go onClick={onDone}>{backLabel ?? "Done"}</Go>
+          <Quiet onClick={start}>Try again</Quiet>
+        </Foot>
+      </>
+    );
+  }
+
+  const settings = accessUrl(provider.clientId);
+
+  return (
+    <>
+      <p className="max-w-[56ch] text-ui leading-[1.6] text-dim">
+        Firetower sees what your {provider.label} account shares with it. Two things
+        can keep a repository out of the list.
+      </p>
+
+      <Path
+        n="1"
+        title="Its organization wasn't granted"
+        body={`Authorize again — ${provider.label} lists every organization with Grant or Request beside it. What you have now is kept until a new authorization is approved, so nothing is lost by trying.`}
+      >
+        <button
+          onClick={start}
+          disabled={authorize.isPending}
+          className="rounded-md border border-line bg-raise px-3 py-1.5 text-meta text-bone transition-colors hover:border-dim disabled:text-mute"
+        >
+          {authorize.isPending ? "Starting…" : "Authorize again"}
+        </button>
+      </Path>
+
+      <Path
+        n="2"
+        title="An owner has to approve it"
+        body={`Organizations that restrict third-party applications stay hidden until somebody with admin rights says yes. Request it there, then ask them.`}
+      >
+        {settings ? (
+          <a
+            href={settings}
+            target="_blank"
+            rel="noopener"
+            className="inline-flex items-center gap-1.5 text-meta text-dim underline underline-offset-2 transition-colors hover:text-bone"
+          >
+            Your {provider.label} application settings
+            <Icon of={ArrowUpRight} size={12} />
+          </a>
+        ) : (
+          <p className="text-meta text-mute">
+            No application is registered, so there is no page to send you to.
+          </p>
+        )}
+      </Path>
+
+      {authorize.isError && <Failure error={authorize.error} />}
+
+      <Foot>
+        <Quiet onClick={onDone}>{backLabel ?? "Done"}</Quiet>
+      </Foot>
+    </>
+  );
+}
+
+function Path({
+  n,
+  title,
+  body,
+  children,
+}: {
+  n: string;
+  title: string;
+  body: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-4 flex gap-3">
+      <span className="mt-[2px] flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border border-line font-mono text-micro text-mute">
+        {n}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-ui text-bone">{title}</p>
+        <p className="mt-0.5 max-w-[54ch] text-meta leading-[1.55] text-dim">{body}</p>
+        <div className="mt-2.5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/Modal.tsx
+++ b/web/components/Modal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
-import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { LoaderCircle, X } from "lucide-react";
 import { Button, Icon } from "./ui";
+import type { PendingAuth } from "@/src/api/generated/model";
+import { ApiError } from "@/src/api/http";
 
 export function Modal({
   title,
@@ -45,7 +47,7 @@ export function Modal({
   );
 }
 
-/* Shared bits used by both connect flows. */
+/* Shared bits used by every flow that authorizes something. */
 
 export function Choice({
   on,
@@ -133,5 +135,86 @@ export function Quiet({
     <Button variant="quiet" onClick={onClick} disabled={disabled}>
       {children}
     </Button>
+  );
+}
+
+/**
+ * The code to type, and the wait for somebody to type it.
+ *
+ * Shared with the screen that widens an existing authorization, which is the
+ * same wait for the same reason and must not drift from this one. `note` is
+ * what differs: re-authorizing is done for the organization list on the
+ * approval screen, and saying so at the moment somebody is looking at that
+ * screen is the whole point of sending them back to it.
+ */
+export function DeviceCode({ pending, note }: { pending: PendingAuth; note?: string }) {
+  return (
+    <>
+      <p className="text-ui text-dim">
+        A tab opened at{" "}
+        <a
+          href={pending.verificationUri}
+          target="_blank"
+          rel="noopener"
+          className="text-dim underline underline-offset-2 transition-colors hover:text-bone"
+        >
+          {pending.verificationUri.replace(/^https?:\/\//, "")}
+        </a>
+        . Enter this code:
+      </p>
+
+      <CodeToType code={pending.userCode} />
+
+      {note && <p className="mt-3 max-w-[54ch] text-meta leading-[1.55] text-dim">{note}</p>}
+
+      <p className="mt-4 flex items-center gap-2 text-meta text-mute">
+        <Spinner />
+        Waiting for you to approve it…
+      </p>
+    </>
+  );
+}
+
+/** Shown, not clicked — so it needs to be readable and copyable. */
+export function CodeToType({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="mt-3 flex items-center gap-3">
+      <code className="rounded-md border border-line bg-raise px-4 py-2.5 font-mono text-display tracking-[0.18em] text-bone">
+        {code}
+      </code>
+      <button
+        onClick={() => {
+          navigator.clipboard.writeText(code);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1600);
+        }}
+        className="text-meta text-mute transition-colors hover:text-text"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The server writes these messages because only it knows which of several
+ * things went wrong. Repeating them verbatim beats a generic line here.
+ */
+export function Failure({ error }: { error: unknown }) {
+  const message =
+    error instanceof ApiError ? error.message : "Something went wrong. Try again.";
+
+  return (
+    <div className="mt-4 rounded-md border border-line bg-raise px-3.5 py-2.5">
+      <p className="text-meta leading-[1.55] text-bone">{message}</p>
+    </div>
+  );
+}
+
+export function Spinner() {
+  return (
+    <Icon of={LoaderCircle} size={12} className="animate-spin" />
   );
 }

--- a/web/components/github-access.test.ts
+++ b/web/components/github-access.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { accessUrl, ownersOf, reach, whatChanged } from "./GitHubAccess";
+import type { RemoteRepo } from "@/src/api/generated/model";
+
+const repo = (slug: string): RemoteRepo => ({
+  slug,
+  remote: `https://github.com/${slug}.git`,
+  defaultBranch: "main",
+  private: false,
+  pushedAt: null,
+});
+
+/**
+ * The question this screen exists to answer: did authorizing again actually
+ * buy anything? A grant that went through and a request still waiting on an
+ * owner look identical from here unless the two lists are compared, and
+ * reporting the second as success is how somebody ends up filing the same
+ * issue twice.
+ */
+describe("what a re-authorization bought", () => {
+  it("names the organizations that became visible", () => {
+    const said = whatChanged(
+      [repo("you/notes")],
+      [repo("you/notes"), repo("acme/backend"), repo("acme/web")],
+    );
+    expect(said).toContain("2 more repositories");
+    expect(said).toContain("acme");
+  });
+
+  it("says plainly when nothing changed", () => {
+    const said = whatChanged([repo("you/notes")], [repo("you/notes")]);
+    expect(said).toContain("Nothing new");
+    // And why, because the next move is asking somebody, not clicking again.
+    expect(said).toContain("owner");
+  });
+
+  it("counts a single repository in the singular", () => {
+    expect(whatChanged([], [repo("acme/backend")])).toContain("1 more repository");
+  });
+
+  it("only names organizations that are new", () => {
+    // A repository added inside an organization already granted is not a new
+    // organization, and saying it is would credit the wrong thing.
+    const said = whatChanged([repo("acme/backend")], [repo("acme/backend"), repo("acme/web")]);
+    expect(said).toBe("1 more repository is visible now.");
+  });
+
+  it("lists several new organizations readably", () => {
+    const said = whatChanged(
+      [],
+      [repo("acme/backend"), repo("labs/thing"), repo("you/notes")],
+    );
+    expect(said).toContain("acme, labs and you");
+  });
+});
+
+describe("who a token can see", () => {
+  it("keeps each owner once, in the order the host returned them", () => {
+    expect(ownersOf([repo("acme/backend"), repo("you/notes"), repo("acme/web")])).toEqual([
+      "acme",
+      "you",
+    ]);
+  });
+
+  it("counts repositories and owners for the settings line", () => {
+    expect(reach([repo("acme/backend")])).toBe("1 repository across 1 account or organization");
+    expect(reach([repo("acme/backend"), repo("you/notes")])).toBe(
+      "2 repositories across 2 accounts and organizations",
+    );
+    // Connected but sharing nothing is a real state, and it should read as one
+    // rather than as an error.
+    expect(reach([])).toBe("0 repositories across 0 accounts and organizations");
+  });
+});
+
+/**
+ * The link is the half of this that authorizing again cannot do, and it is
+ * unbuildable without the client id — which is why the status carries one.
+ */
+describe("where access is reviewed on the host", () => {
+  it("is built from the client id being authorized against", () => {
+    expect(accessUrl("Ov23liEXAMPLE")).toBe(
+      "https://github.com/settings/connections/applications/Ov23liEXAMPLE",
+    );
+  });
+
+  it("is nothing at all when no application is registered", () => {
+    // Rather than a link to a page that 404s, which reads as our bug.
+    expect(accessUrl(null)).toBeNull();
+    expect(accessUrl(undefined)).toBeNull();
+    expect(accessUrl("  ")).toBeNull();
+  });
+});

--- a/web/src/api/generated/model/providerStatus.ts
+++ b/web/src/api/generated/model/providerStatus.ts
@@ -12,6 +12,17 @@ import type { PendingAuth } from './pendingAuth';
  */
 export interface ProviderStatus {
   /**
+     * The identifier being authorized against, when there is one.
+     *
+     * Sent so the interface can link to the page on the host where this
+     * application's access is reviewed — the only place an organization that
+     * restricts third-party applications can be requested after the fact, and
+     * the address of it contains the client id. Public by design: a
+     * device-flow application has no paired secret.
+     * @nullable
+     */
+  clientId?: string | null;
+  /**
      * False when nobody has registered an application for this build, which is
      * a setup problem rather than something the person using it did wrong.
      */

--- a/web/src/api/generated/providers/providers.zod.ts
+++ b/web/src/api/generated/providers/providers.zod.ts
@@ -9,6 +9,7 @@ import * as zod from 'zod';
 
 
 export const ListProvidersResponseItem = zod.object({
+  "clientId": zod.string().nullish().describe('The identifier being authorized against, when there is one.\n\nSent so the interface can link to the page on the host where this\napplication\'s access is reviewed — the only place an organization that\nrestricts third-party applications can be requested after the fact, and\nthe address of it contains the client id. Public by design: a\ndevice-flow application has no paired secret.'),
   "configured": zod.boolean().describe('False when nobody has registered an application for this build, which is\na setup problem rather than something the person using it did wrong.'),
   "connected": zod.boolean().describe('We hold a token for it.'),
   "id": zod.string(),

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+/**
+ * `@/` means the same thing under a test as it does under Next.
+ *
+ * Without this, a test can only reach a module whose own imports are all
+ * relative — which quietly decides what is testable, and the answer was
+ * "not components". Everything else stays default.
+ */
+export default defineConfig({
+  resolve: {
+    alias: { "@": fileURLToPath(new URL(".", import.meta.url)) },
+  },
+});


### PR DESCRIPTION
Closes firetower-cloud/firetower#33

When you connect GitHub, its approval screen is where you choose which
organizations Firetower may see — and that screen is shown exactly once. Skip
an organization there, or join one afterwards, and there has never been a way
back to it: the picker simply doesn't list those repositories and nothing says
why. The only escape was
`github.com/settings/connections/applications/<client id>`, which nothing in
the product linked to.

The scope isn't the problem — `repo` is already the widest an OAuth app has.
The missing piece is the organization grant, and the way to it is authorizing
again, which shows the approval screen with Grant or Request beside every
organization.

## What this adds

- **A GitHub access panel on the repositories page** — what the token can
  currently see ("24 repositories across 3 accounts and organizations — acme ·
  acme-labs · you"), and a way into the screen below.
- **Two paths, because GitHub makes them different.** ① Authorize again, for
  organizations you can grant yourself. ② A link to your GitHub application
  settings, for organizations that restrict third-party applications and need
  an owner to approve the request.
- **An honest outcome.** The repository list before and after are compared, so
  a grant that went through reads as "2 more repositories are visible now, from
  acme" — and a request still waiting on an owner reads as "Nothing new is
  visible", rather than as success.
- **The same door from inside the picker** — "Missing one? Add an
  organization", which is where the gap is actually noticed, and which returns
  you to a refetched list.

Nothing is risked by trying: the control plane writes a token only when a new
authorization is approved, so one that is abandoned, declined or expired leaves
the working token untouched.

## Changes

- `ProviderStatus` carries the `clientId` being authorized against — the
  settings address is unbuildable without it, and a device-flow client id is
  public by design.
- `authorize_provider` needed no logic change; the guarantee above is now
  recorded in its doc comment.
- `DeviceCode`, `CodeToType`, `Failure` and `Spinner` moved from `ConnectRepo`
  to `Modal`: both flows show the same wait, and leaving them in `ConnectRepo`
  made an import cycle.
- `web/vitest.config.ts` — vitest had no `@/` alias, so a test could only reach
  a module whose own imports were all relative.

## Verification

`tsc`, `eslint` and 87 web tests pass, including 9 new ones. One of them caught
a real bug on the way in ("1 more repository *are* visible now").

**`cargo test` and `just gen` have not been run** — no Rust toolchain on the
machine this was written on. The `clientId` entry in `api/openapi.json` is
hand-written to match what utoipa emits for a documented `Option<String>`;
orval was then run against it for real, so the generated client is genuine, but
`just gen-check` is what confirms the hand-written half.