### PR TITLE
feat: close a workspace from any view of the panel

### DIFF
--- a/web/components/workspace/CloseWorkspace.tsx
+++ b/web/components/workspace/CloseWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useDestroySession,
@@ -12,14 +13,17 @@ import {
 import { useListHosts } from "@/src/api/generated/hosts/hosts";
 import type { Session } from "@/src/api/generated/model";
 import { Modal, Foot, Go, Quiet } from "@/components/Modal";
+import { Icon } from "@/components/ui";
 import { ApiError } from "@/src/api/http";
 
 /**
  * The way out of a workspace, wherever it got to.
  *
  * Ending one was only ever reachable by closing an agent's tab, which ends
- * that agent — a thing you had to already know. Most workspaces never get a
- * pull request, so the common way to finish with one had no button at all.
+ * that agent — a thing you had to already know. Then it was a word at the
+ * bottom of the Ship view, which is better and still filed the only control
+ * that ends a workspace under the one thing most workspaces never do. It lives
+ * on the panel's status line now, under every view; see `Doing`.
  *
  * It says what it is about to destroy first. This removes a worktree from a
  * machine, and uncommitted work in it does not come back.
@@ -87,10 +91,16 @@ export function CloseWorkspace({
         className={
           prominent
             ? "w-full rounded-md bg-bone py-2 text-meta font-medium text-ground transition-colors hover:bg-white"
-            : "rounded-sm px-1.5 py-0.5 text-meta text-mute transition-colors hover:text-brick"
+            : // Outlined rather than filled: this is a way out, not a next
+              // step, and the filled control in this panel is the one that
+              // ships. It turns brick under the pointer instead of resting
+              // that way — the only destructive control on screen should say
+              // so before it is pressed, without sitting there as a warning.
+              "flex shrink-0 items-center gap-1.5 rounded-md border border-line px-2 py-0.5 text-meta text-dim transition-colors hover:border-brick-deep hover:bg-brick-tint hover:text-brick"
         }
       >
-        {prominent ? "Close the workspace" : "Close"}
+        {!prominent && <Icon of={LogOut} size={12} />}
+        Close workspace
       </button>
 
       {asking && (

--- a/web/components/workspace/Inspector.tsx
+++ b/web/components/workspace/Inspector.tsx
@@ -4,16 +4,22 @@ import { FileDiff, FolderOpen, GitBranch, PanelRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Icon } from "@/components/ui";
 import { useState } from "react";
-import { useGetSession, useSessionDiff } from "@/src/api/generated/sessions/sessions";
+import {
+  useGetSession,
+  useSessionDiff,
+  useSessionWork,
+} from "@/src/api/generated/sessions/sessions";
 import { useOpen } from "@/src/workspace/tabs";
 import { usePanel, VIEWS, type View } from "@/src/workspace/panel";
 import { Signal } from "@/components/Signal";
 import { STATUS_LABEL } from "@/src/api/view";
+import { shipping } from "@/src/api/ship";
 import { useListEvents } from "@/src/api/generated/events/events";
 import { stepLines, ready } from "@/components/Steps";
 import { PathRow, Counts } from "./PathRow";
 import { Tree } from "./Tree";
 import { ShipPanel } from "./ShipPanel";
+import { CloseWorkspace } from "./CloseWorkspace";
 
 /**
  * The workspace of whatever is in front of you.
@@ -213,17 +219,36 @@ function Grip() {
 }
 
 /**
- * What the session is doing, pinned under every view.
+ * What the session is doing, and the way out of it, pinned under every view.
  *
  * The answer to "is it still going" was at the bottom of the transcript, which
  * meant scrolling away from whatever you were reading to find it. It is one
  * line, and it belongs somewhere that does not move.
+ *
+ * Closing sits on that line. It used to be a word at the bottom of the Ship
+ * view — so the only control that ends a workspace was filed under the one
+ * thing most workspaces never do, and you had to already know it was there.
+ * This row is the part of the panel that talks *about* the workspace rather
+ * than showing a view of it, which makes it the honest place for the exit and
+ * the reason it is under every view rather than one of them.
+ *
+ * A fourth glyph in the strip was the other candidate and is worse: the strip
+ * is a set of views, and one of them silently being a destructive action is a
+ * thing you only mispress once.
  */
 function Doing({ sessionId }: { sessionId: string }) {
   const { data: session } = useGetSession(sessionId);
   // The same query the session tab runs, served from one cache entry — and kept
   // current by the socket rather than by either of them polling.
   const { data: events = [] } = useListEvents({ since: 0, sessionId });
+  // No interval of its own. Ship polls this same cache entry while it is open,
+  // and all this reads from it is whether the work went in — which, once it
+  // has, does not go back to open. Asking the git host on every view, for every
+  // workspace somebody has open, to decide how to draw one button is not worth
+  // the requests.
+  const { data: work } = useSessionWork(sessionId, {
+    query: { enabled: !!session?.repo, staleTime: 30_000 },
+  });
 
   if (!session) return null;
 
@@ -235,18 +260,29 @@ function Doing({ sessionId }: { sessionId: string }) {
   const now = ready(lines) ? undefined : lines.find((l) => l.state === "running");
   const under = now?.detail || (now ? LABEL[now.step] : undefined);
 
+  // Merged is the one state where closing is the next thing to do rather than
+  // one of the things you may do, so it takes the room to say so — in place of
+  // the quiet one on the status line, never beside it.
+  const finished = shipping(session, work).stage === "merged";
+
   return (
     <div className="shrink-0 border-t border-line px-3 py-2">
       <div className="flex items-center gap-2">
         <Signal status={session.status} size={6} />
-        <span className="truncate text-meta text-dim">
+        <span className="min-w-0 flex-1 truncate text-meta text-dim">
           {STATUS_LABEL[session.status] ?? session.status}
         </span>
+        {!finished && <CloseWorkspace session={session} />}
       </div>
       {under && (
         <p className="mt-0.5 truncate pl-[14px] font-mono text-micro text-mute" title={under}>
           {under}
         </p>
+      )}
+      {finished && (
+        <div className="mt-2">
+          <CloseWorkspace session={session} prominent />
+        </div>
       )}
     </div>
   );

--- a/web/components/workspace/ShipPanel.tsx
+++ b/web/components/workspace/ShipPanel.tsx
@@ -17,7 +17,6 @@ import { shipping, sequence, done, awaiting } from "@/src/api/ship";
 import { ApiError } from "@/src/api/http";
 import { useOpen } from "@/src/workspace/tabs";
 import { PathRow, Counts, Fold } from "./PathRow";
-import { CloseWorkspace } from "./CloseWorkspace";
 
 /**
  * Everything between "it finished" and "it is on the git host".
@@ -231,9 +230,6 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
               </div>
             )}
 
-            {/* The next thing to do, once there is nothing left to review. */}
-            {ship.stage === "merged" && <CloseWorkspace session={session} prominent />}
-
             {ship.links.map((l) => (
               <a
                 key={l.url}
@@ -329,13 +325,6 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
             </p>
           )}
         </Fold>
-      </div>
-
-      {/* Always, whatever the stage. Most workspaces never get a pull request,
-          so the way to finish with one cannot live in the half of the panel
-          that only appears when there is one. */}
-      <div className="flex shrink-0 items-center justify-end border-t border-line px-2 py-1.5">
-        <CloseWorkspace session={session} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #31.

Closing a workspace was a word at the bottom of the Ship view. That filed the
only control that ends a workspace under the one thing most workspaces never
do — you had to already know it was there, and on Files or Changes there was
no way out at all.

It moves to the panel's status line, under every view. That row is the part of
the panel that talks *about* the workspace rather than showing a view of it,
which makes it the honest place for the exit and the reason it does not belong
to any one tab.

- **`Doing` in `Inspector.tsx`** renders `CloseWorkspace` beside the status
  light, so it is there on Files, Changes and Ship alike. A merged workspace
  gets the full-width prominent variant below the line *instead of* the quiet
  one, never both.
- **`CloseWorkspace`** goes from mute text to an outlined button with a glyph,
  reading **Close workspace**. It turns brick under the pointer rather than
  resting that way: the only destructive control on screen should say so
  before it is pressed, without sitting there as a permanent warning.
- **`ShipPanel`** loses both call sites. One control, one place.

Merged is read from `useSessionWork` with a `staleTime` and no interval of its
own, so it rides the cache entry Ship already polls — deciding how to draw one
button is not worth asking the git host on every view, for every workspace
somebody has open.

Nothing about the gate changes. Every route still lands in the same dialog,
which names the host, counts what would be lost across every repository in the
workspace, and says when the founding session takes the others with it. The
trigger is visible; the action is not cheaper.

### Not in this change

- **Collapsed panel.** Shut to the 38px strip there is no footer, so no way
  out. Pinning the same glyph to the bottom of the strip is the fix, and is
  the smallest follow-up here.
- **Below `xl`.** The panel is `hidden … xl:flex`, so a narrow window still
  has nothing. The workspace's own row in the rail is the answer, and
  `SessionMenu` — which already has Get it locally / Stop the agent / End, and
  has been rendered nowhere since the session header was removed — is where it
  would go.

### Checks

`tsc --noEmit`, `eslint` and `just check-style` clean; 78 tests in 9 files
pass. Not run against a live control plane, so the layout is verified by
reading rather than by pixels.