### PR TITLE
fix: ⌘P opens the file search from anywhere in a session

### DIFF
--- a/web/components/workspace/Finder.tsx
+++ b/web/components/workspace/Finder.tsx
@@ -6,7 +6,8 @@
  * Two ways in, one list. The rail carries a filter above the tree, for when you
  * are already looking at the workspace; `⌘P` opens the same list over the
  * middle pane, for when you are not — and that one is muscle memory from every
- * editor anybody arrives here from.
+ * editor anybody arrives here from. The rail says so, on a chip beside its
+ * filter: a shortcut nobody has been told about is a shortcut nobody has.
  *
  * The matching happens on the machine that holds the workspace. The alternative
  * is sending the whole path index to the browser and filtering it here, which
@@ -14,13 +15,14 @@
  * down a pipe shared with every terminal on that host.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { Search } from "lucide-react";
 import { useFindFiles } from "@/src/api/generated/sessions/sessions";
 import { Icon } from "@/components/ui";
 import { FileGlyph } from "@/components/FileGlyph";
 import { useCurrentSession, useOpen } from "@/src/workspace/tabs";
 import { reveal } from "@/src/workspace/tree";
+import { isFindFile } from "@/src/workspace/keys";
 
 /** Long enough that a fast typist sends one search, not eight. */
 const SETTLE = 120;
@@ -75,6 +77,36 @@ export function Results({
 }
 
 /**
+ * Whether the finder is up.
+ *
+ * A module store rather than component state, for the same reason the tree is
+ * one: the finder is mounted over the middle pane and the chip advertising it
+ * sits in the rail, and there is nothing between the two to thread a callback
+ * through.
+ *
+ * Not kept anywhere. A search box that happened to be open when a tab was
+ * closed is not a thing to restore somebody to.
+ */
+let up = false;
+const watching = new Set<() => void>();
+
+function listen(onChange: () => void) {
+  watching.add(onChange);
+  return () => void watching.delete(onChange);
+}
+
+function show(next: boolean) {
+  if (up === next) return;
+  up = next;
+  for (const tell of watching) tell();
+}
+
+/** Open the finder from somewhere that is not the keyboard. */
+export function openFinder() {
+  show(true);
+}
+
+/**
  * The same list, over the middle pane, on `⌘P`.
  *
  * It listens for the key itself rather than going through `useWorkbenchKeys`,
@@ -86,33 +118,57 @@ export function Results({
  * and every editor this replaces has trained the same two keys.
  */
 export function Finder() {
-  const [open, setOpen] = useState(false);
+  const open = useSyncExternalStore(listen, () => up, () => false);
+  const sessionId = useCurrentSession();
+
+  useEffect(() => {
+    // Nothing to find outside a workspace, and taking the key there would make
+    // it a dead one: no print, no finder, no answer at all.
+    if (!sessionId) {
+      show(false);
+      return;
+    }
+
+    const pressed = (e: KeyboardEvent) => {
+      if (!isFindFile(e)) return;
+      e.preventDefault();
+      // Read through the store rather than a captured value: the listener is
+      // registered once per session and would otherwise toggle against
+      // whatever was true when it was.
+      show(!up);
+    };
+
+    // Captured, so this is the first handler to see the key rather than the
+    // last. Nothing on the way up swallows a `p` today, but `Chat` already
+    // stops a `⌘↵` from the same phase, and the next one to do that would
+    // silently give ⌘P back to the printer.
+    window.addEventListener("keydown", pressed, true);
+    return () => window.removeEventListener("keydown", pressed, true);
+  }, [sessionId]);
+
+  if (!open || !sessionId) return null;
+  return <Overlay sessionId={sessionId} />;
+}
+
+/**
+ * The box itself, mounted only while it is up.
+ *
+ * Which is what empties it. Every opening should start on a blank query at the
+ * first row, and a component that only exists while the finder is open gets
+ * that from its own initial state rather than from an effect reaching back to
+ * clear the last visit.
+ */
+function Overlay({ sessionId }: { sessionId: string }) {
   const [q, setQ] = useState("");
   const [at, setAt] = useState(0);
-  const sessionId = useCurrentSession();
   const openTab = useOpen();
   const field = useRef<HTMLInputElement>(null);
 
-  const { paths, waiting } = useFind(sessionId ?? "", sessionId ? q : "");
+  const { paths, waiting } = useFind(sessionId, q);
 
   useEffect(() => {
-    const pressed = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === "p") {
-        e.preventDefault();
-        setQ("");
-        setAt(0);
-        setOpen(true);
-      }
-    };
-    window.addEventListener("keydown", pressed);
-    return () => window.removeEventListener("keydown", pressed);
+    field.current?.focus();
   }, []);
-
-  useEffect(() => {
-    if (open) field.current?.focus();
-  }, [open]);
-
-  if (!open || !sessionId) return null;
 
   // Clamped rather than reset from an effect: a shorter list arriving under a
   // cursor sitting on row nine is a render, not an event to react to.
@@ -121,11 +177,11 @@ export function Finder() {
   const take = (path: string, beside: boolean) => {
     reveal(sessionId, path);
     openTab.file(path, beside);
-    setOpen(false);
+    show(false);
   };
 
   const typed = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape") return setOpen(false);
+    if (e.key === "Escape") return show(false);
     if (e.key === "ArrowDown") {
       e.preventDefault();
       return setAt(paths.length ? (cursor + 1) % paths.length : 0);
@@ -142,7 +198,7 @@ export function Finder() {
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-[14vh]">
-      <div className="fixed inset-0 bg-ground/70 backdrop-blur-[3px]" onClick={() => setOpen(false)} />
+      <div className="fixed inset-0 bg-ground/70 backdrop-blur-[3px]" onClick={() => show(false)} />
 
       <div className="relative w-full max-w-[560px] overflow-hidden rounded-lg border border-line bg-panel shadow-float">
         <div className="flex items-center gap-2 border-b border-line px-3 py-2.5">

--- a/web/components/workspace/Tree.tsx
+++ b/web/components/workspace/Tree.tsx
@@ -25,7 +25,7 @@ import { Icon } from "@/components/ui";
 import { FileGlyph } from "@/components/FileGlyph";
 import { useOpen, useTabs } from "@/src/workspace/tabs";
 import { useRevealed, useTree } from "@/src/workspace/tree";
-import { Results } from "./Finder";
+import { openFinder, Results } from "./Finder";
 
 /** One level of nesting, in pixels. Deep enough to read, tight enough to fit. */
 const STEP = 12;
@@ -164,7 +164,14 @@ function Body({ sessionId, children }: { sessionId: string; children: React.Reac
   );
 }
 
-/** Find a file by name, without leaving the panel. */
+/**
+ * Find a file by name, without leaving the panel.
+ *
+ * The chip on the right is the only place `⌘P` is written down. It is the one
+ * spot somebody already looks when they want to find a file, which makes it the
+ * one spot worth teaching the shortcut from — and it is pressable, because a
+ * hint you cannot act on is a hint that has to be believed rather than tried.
+ */
 function Filter({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-b border-line px-3 py-1.5">
@@ -177,13 +184,22 @@ function Filter({ value, onChange }: { value: string; onChange: (v: string) => v
         aria-label="Find a file"
         className="min-w-0 flex-1 bg-transparent text-ui text-text placeholder:text-mute focus:outline-none"
       />
-      {value && (
+      {value ? (
         <button
           onClick={() => onChange("")}
           aria-label="Clear"
           className="shrink-0 rounded-sm p-0.5 text-mute transition-colors hover:text-bone"
         >
           <Icon of={X} size={12} />
+        </button>
+      ) : (
+        <button
+          onClick={openFinder}
+          title="Find a file from anywhere"
+          aria-label="Find a file from anywhere"
+          className="shrink-0 rounded-sm px-1 py-0.5 font-mono text-micro text-mute transition-colors hover:bg-raise/60 hover:text-bone"
+        >
+          ⌘P
         </button>
       )}
     </div>

--- a/web/src/workspace/keys.test.ts
+++ b/web/src/workspace/keys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isFindFile } from "./keys";
+
+/**
+ * A `keydown` as the browser would give it, with the defaults a plain press has.
+ *
+ * `code` is the key's place on the board and `key` is what that place produces
+ * under the current layout. They are the same thing on a US keyboard and are
+ * not on most others, which is the whole reason this predicate reads both.
+ */
+const press = (over: Partial<KeyboardEvent>): KeyboardEvent =>
+  ({
+    key: "p",
+    code: "KeyP",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...over,
+  }) as KeyboardEvent;
+
+describe("⌘P means find a file", () => {
+  it("takes the key on either modifier", () => {
+    expect(isFindFile(press({ metaKey: true }))).toBe(true);
+    expect(isFindFile(press({ ctrlKey: true }))).toBe(true);
+  });
+
+  it("leaves a bare P to whoever is typing", () => {
+    expect(isFindFile(press({}))).toBe(false);
+  });
+
+  it("is the physical key, not the letter it happens to make", () => {
+    // AZERTY, Dvorak, Colemak: the P people press is the P people press, and
+    // the character underneath it is not always a `p`.
+    expect(isFindFile(press({ metaKey: true, key: "r", code: "KeyP" }))).toBe(true);
+    // And a layout that reports no useful `code` still works off the letter.
+    expect(isFindFile(press({ metaKey: true, key: "P", code: "" }))).toBe(true);
+  });
+
+  it("leaves ⇧⌘P alone, which is where a command palette goes", () => {
+    expect(isFindFile(press({ metaKey: true, shiftKey: true }))).toBe(false);
+  });
+
+  it("leaves ⌥⌘P alone", () => {
+    expect(isFindFile(press({ metaKey: true, altKey: true }))).toBe(false);
+  });
+
+  it("does not answer for its neighbours on the board", () => {
+    expect(isFindFile(press({ metaKey: true, key: "o", code: "KeyO" }))).toBe(false);
+    expect(isFindFile(press({ metaKey: true, key: "[", code: "BracketLeft" }))).toBe(false);
+  });
+});

--- a/web/src/workspace/keys.ts
+++ b/web/src/workspace/keys.ts
@@ -8,13 +8,36 @@
  * something else inside one page is the kind of cleverness that loses somebody
  * a tab they meant to keep, so closing is `⌘⌥W` and there is no `⌘T`.
  *
- * Nothing here fires while a field has focus. A person typing a message is
- * typing a message, and `1` in a prompt must never mean "go to the first tab".
+ * Nothing in `useWorkbenchKeys` fires while a field has focus. A person typing
+ * a message is typing a message, and `1` in a prompt must never mean "go to the
+ * first tab".
+ *
+ * `⌘P` is the exception on both counts — it takes a browser shortcut, and it
+ * takes it while somebody is typing. It is still described here, with the rest
+ * of the keyboard, because a rule about what a key means belongs in one file
+ * even when the component that acts on it lives somewhere else. The finder
+ * reads it: see `isFindFile`.
  */
 
 import { useEffect } from "react";
 import { paneTabs, useTabs } from "./tabs";
 import { revealPanel, VIEWS } from "./panel";
+
+/**
+ * ⌘P — find a file.
+ *
+ * The one browser shortcut this app takes. Nobody prints a workbench, and every
+ * editor somebody arrives here from has trained the same two keys; the browser's
+ * own File › Print is still there for the case that proves us wrong.
+ *
+ * Matched on the physical key as well as the character it produces, so the P of
+ * an AZERTY or Dvorak keyboard is the P people press. `⇧⌘P` is deliberately not
+ * this — it is where a command palette goes.
+ */
+export function isFindFile(e: KeyboardEvent): boolean {
+  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return false;
+  return e.code === "KeyP" || e.key.toLowerCase() === "p";
+}
 
 export function useWorkbenchKeys() {
   const { set, focus, close, move, unsplit, focusPane } = useTabs();


### PR DESCRIPTION
Closes #30.

⌘P has opened the finder since `f059c14`, and the report says it prints. The
handler was on `window` in the bubble phase, so anything between the key and
the window could take it first — nothing does today, but `Chat` already stops
a `⌘↵` from the capture phase, and the next one to do that would hand ⌘P back
to the printer without a test failing. It now listens in capture, which makes
it the first handler to see the key rather than the last.

Three more things it was getting wrong:

It matched `e.key` only. On AZERTY and Dvorak the physical P reports a
different character, so the key every editor has trained was the one key that
did not work. It reads `e.code` too.

Outside a workspace it called `preventDefault` and then rendered nothing —
no print, no finder, no answer. It now leaves the key alone when there is no
session to search.

It only opened. ⌘P, glance, ⌘P to dismiss is muscle memory from the editors
this borrows the shortcut from; a second press now closes it.

The rule itself moved to `keys.ts`, which is where this app says what its
keyboard means, and is now a pure predicate with tests — there is no DOM test
environment here, so a rule that lives inside a `useEffect` cannot be checked
at all.

The other half of #30 is that the reporter did not know the shortcut existed:
the rail's filter was the only visible way to find a file. That row now carries
a `⌘P` chip, and the chip is pressable, so the shortcut can be tried rather
than believed.

Printing this page is gone, deliberately — nobody prints a workbench, and
File › Print still works from the browser's own menu.

**Known limit:** focus inside a preview tab belongs to the framed app, which is
a different origin. ⌘P there is the browser's, and we cannot reach it. Left
alone on purpose.

## Try it

Open a session and press ⌘P with focus in each of: the composer, the file tree,
a shell tab, and nowhere in particular. Each should open the finder; a second
press should close it. Then press the ⌘P chip beside the rail's filter.