### PR TITLE
feat: keep the control plane on loopback, and TLS behind a profile

### DIFF
--- a/crates/ft-server/src/api/forwards.rs
+++ b/crates/ft-server/src/api/forwards.rs
@@ -74,7 +74,9 @@ pub(super) async fn preview_address(
     };
 
     Ok(Json(PreviewAddress {
-        url: state.names.url(scheme_of(&headers), &preview),
+        url: state
+            .names
+            .url(scheme_of(&headers), port_of(&headers), &preview),
         port: which.port,
     }))
 }
@@ -93,6 +95,34 @@ fn scheme_of(headers: &HeaderMap) -> &'static str {
     } else {
         "http"
     }
+}
+
+/// The port the browser reached us on, if it named one.
+///
+/// The same problem as [`scheme_of`], for the same reason: this process only
+/// ever listens on 4400, so its own socket says nothing about the address in
+/// somebody's browser. `Host` carries it, and a proxy that moved the port says
+/// so in `X-Forwarded-Port` — asked first, exactly as `X-Forwarded-Proto` is.
+///
+/// `None` when the header names no port, which means the browser is using the
+/// scheme's default and the URL should not name one either.
+fn port_of(headers: &HeaderMap) -> Option<u16> {
+    let forwarded = headers
+        .get("x-forwarded-port")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse().ok());
+
+    if forwarded.is_some() {
+        return forwarded;
+    }
+
+    let host = headers.get(header::HOST)?.to_str().ok()?;
+
+    // From the right, so that an IPv6 literal's own colons are not mistaken
+    // for the separator: `[::1]:8080` splits after the bracket, and a bare
+    // `[::1]` splits into something that does not parse as a port.
+    let (_, port) = host.rsplit_once(':')?;
+    port.parse().ok()
 }
 
 /// What the interface needs to decide what to show.
@@ -265,4 +295,54 @@ async fn already_reachable(state: &AppState, host: &ft_core::HostId) -> bool {
         state.db.host_by_id(host).await,
         Ok(Some(host)) if host.compute == ft_core::Compute::Local
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                axum::http::HeaderName::from_bytes(name.as_bytes()).expect("a header name"),
+                value.parse().expect("a header value"),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn the_port_comes_from_the_host_header() {
+        assert_eq!(port_of(&headers(&[("host", "localhost:8080")])), Some(8080));
+    }
+
+    #[test]
+    fn no_port_in_the_host_means_the_schemes_default() {
+        // Not `Some(80)`: the caller leaves the port out of the URL entirely,
+        // and saying "80" here would be a guess about the scheme.
+        assert_eq!(
+            port_of(&headers(&[("host", "firetower.example.com")])),
+            None
+        );
+    }
+
+    #[test]
+    fn a_proxy_that_moved_the_port_is_believed_first() {
+        let map = headers(&[("host", "firetower:4400"), ("x-forwarded-port", "443")]);
+        assert_eq!(port_of(&map), Some(443));
+    }
+
+    #[test]
+    fn an_ipv6_literal_is_not_split_on_its_own_colons() {
+        assert_eq!(port_of(&headers(&[("host", "[::1]:8080")])), Some(8080));
+        assert_eq!(port_of(&headers(&[("host", "[::1]")])), None);
+    }
+
+    #[test]
+    fn nonsense_is_no_port_rather_than_a_wrong_one() {
+        assert_eq!(port_of(&headers(&[("host", "localhost:")])), None);
+        assert_eq!(port_of(&headers(&[("host", "localhost:http")])), None);
+        assert_eq!(port_of(&HeaderMap::new()), None);
+    }
 }

--- a/crates/ft-server/src/lib.rs
+++ b/crates/ft-server/src/lib.rs
@@ -557,12 +557,19 @@ fn operational(state: AppState) -> axum::Router {
         .route("/healthz", get(|| async { "ok" }))
         // Whether a hostname is a preview of ours.
         //
-        // Caddy asks before it will request a certificate for a name it has
-        // never seen, which is what stops anybody pointing a domain at a
-        // deployment and having it mint certificates on request. Outside the
-        // gate because Caddy has no credential — and it needs none: this
-        // answers a question anybody could answer for themselves by trying the
-        // name.
+        // Whether a preview hostname is one we signed.
+        //
+        // **Nothing asks this today.** It was Caddy's `on_demand_tls ask`,
+        // back when a certificate was obtained per preview hostname — which
+        // also meant publishing each one to Certificate Transparency logs,
+        // where a hostname that *is* the credential for that preview does not
+        // belong. The deployment now terminates TLS with one wildcard
+        // certificate and mints nothing on demand.
+        //
+        // Kept because it costs nothing and is the right answer for any future
+        // issuer that needs to ask. Outside the gate because whoever asks has
+        // no credential — and needs none: this answers a question anybody
+        // could answer for themselves by trying the name.
         .route(
             "/preview-known",
             get(

--- a/crates/ft-server/src/preview.rs
+++ b/crates/ft-server/src/preview.rs
@@ -85,11 +85,25 @@ impl Names {
 
     /// The whole address, ready to put in an `iframe`.
     ///
-    /// Scheme included, and it is the caller's: a deployment behind Caddy with
-    /// a domain is on https, a laptop is not, and only the request that asked
-    /// knows which.
-    pub fn url(&self, scheme: &str, preview: &Preview) -> String {
-        format!("{scheme}://{}/", self.host(preview))
+    /// Scheme and port are both the caller's, because only the request that
+    /// asked knows either: a deployment behind Caddy with a certificate is
+    /// https on 443, and a control plane reached through an ssh tunnel is http
+    /// on whatever the operator forwarded.
+    ///
+    /// The port has to be here. A preview is a link the browser follows on its
+    /// own, so leaving it out of `localhost:8080` does not mean "the port I
+    /// came in on" — it means port 80, on the machine holding the browser,
+    /// where there is either nothing or something else of theirs.
+    ///
+    /// It is left out when it *is* the default for the scheme, so the ordinary
+    /// case does not grow a `:443` that nobody typed.
+    pub fn url(&self, scheme: &str, port: Option<u16>, preview: &Preview) -> String {
+        let host = self.host(preview);
+
+        match port {
+            Some(port) if !default_port(scheme, port) => format!("{scheme}://{host}:{port}/"),
+            _ => format!("{scheme}://{host}/"),
+        }
     }
 
     /// The hostname for a session's port.
@@ -147,6 +161,15 @@ impl Names {
 
         base32(&mac.finalize().into_bytes()[..SIGNATURE_BYTES])
     }
+}
+
+/// Whether a browser would have assumed this port from the scheme alone.
+///
+/// Only these two: a URL is not improved by `:8080` becoming implicit anywhere
+/// else, and guessing wrong here produces a link to the wrong port rather than
+/// an ugly one.
+fn default_port(scheme: &str, port: u16) -> bool {
+    matches!((scheme, port), ("http", 80) | ("https", 443))
 }
 
 /// Previews hang off this when nothing says otherwise.
@@ -446,7 +469,56 @@ mod tests {
     #[test]
     fn the_url_carries_the_callers_scheme() {
         let names = names();
-        assert!(names.url("https", &preview()).starts_with("https://"));
-        assert!(names.url("http", &preview()).ends_with("/"));
+        assert!(names.url("https", None, &preview()).starts_with("https://"));
+        assert!(names.url("http", None, &preview()).ends_with("/"));
+    }
+
+    #[test]
+    fn the_url_carries_the_callers_port() {
+        let names = names();
+        let host = names.host(&preview());
+
+        // The tunnel case, and the whole reason the port is threaded through:
+        // without it this link goes to port 80 of the browser's own machine.
+        assert_eq!(
+            names.url("http", Some(8080), &preview()),
+            format!("http://{host}:8080/")
+        );
+        assert_eq!(
+            names.url("https", Some(8443), &preview()),
+            format!("https://{host}:8443/")
+        );
+    }
+
+    #[test]
+    fn a_default_port_is_left_out() {
+        let names = names();
+        let host = names.host(&preview());
+
+        assert_eq!(
+            names.url("http", Some(80), &preview()),
+            format!("http://{host}/")
+        );
+        assert_eq!(
+            names.url("https", Some(443), &preview()),
+            format!("https://{host}/")
+        );
+
+        // Default for the *other* scheme is still a port worth printing.
+        assert_eq!(
+            names.url("http", Some(443), &preview()),
+            format!("http://{host}:443/")
+        );
+    }
+
+    #[test]
+    fn a_ported_url_still_resolves_back() {
+        let names = names();
+        let url = names.url("http", Some(8080), &preview());
+
+        // What the browser will put in `Host` for that link, which is what
+        // `preview_first` has to recognise on the way back in.
+        let authority = url.trim_start_matches("http://").trim_end_matches('/');
+        assert_eq!(names.resolve(authority), Some(preview()));
     }
 }

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -3,49 +3,120 @@
 # Everything here is something you have to decide. The contributors' file at
 # the repository root is the opposite — every value in that one has a working
 # default, because it is for people running from a checkout.
+#
+# There are two shapes, and the first one needs nothing from this section at
+# all. Read both before you change anything.
 
-# Where Firetower will live.
-#
-# Point an A record at this machine first and check it with
-# `dig +short firetower.example.com` — Caddy proves you own the name by
-# answering on port 80, so both 80 and 443 have to be open to the internet.
-#
-# Leave it unset and Firetower serves plain HTTP, which is what you want when
-# it is only ever reached from this machine — and when a reverse proxy you
-# already run is the thing holding the certificate.
-DOMAIN=firetower.example.com
 
-# Which ports Caddy publishes on this machine.
+# ── Shape 1: reached from your own machine ───────────────────────────────────
 #
-# **Leave these alone if DOMAIN is set above.** Let's Encrypt answers the
-# certificate challenge on 80 and 443 specifically, so moving either one means
-# no certificate — and a challenge that keeps failing earns a rate limit
-# measured in days.
+# The default, and the one to want. Firetower publishes a port on 127.0.0.1
+# and nothing else on this machine listens for you: no proxy container is
+# created, no certificate exists, and nothing is reachable from the network.
 #
-# Move them when there is no domain here. Two reasons to:
+# You reach it with an ssh tunnel from wherever you actually sit:
 #
-#   * something already answers on 80 — another site, another container — and
-#     Compose would refuse to start rather than share it;
-#   * a reverse proxy you already run holds 80 and 443 and will pass requests
-#     through to Firetower. Leave DOMAIN empty, publish here, point that proxy
-#     at this port, and set FIRETOWER_PUBLIC_URL below to the address it serves.
+#   ssh -N -L 8080:127.0.0.1:8080 \
+#       -o ServerAliveInterval=20 -o ServerAliveCountMax=3 \
+#       -o ExitOnForwardFailure=yes you@this-machine
 #
-# Nothing answers on the HTTPS port without a domain, so 443 is only worth
-# moving when something else wants it.
+#   then open http://localhost:8080
+#
+# `firetower tunnel you@this-machine` runs exactly that, if you have the CLI
+# on your own machine. The keepalives are not decoration: without them the
+# forward dies silently on sleep or a network change and does not come back.
+#
+# Nothing below in this section needs setting for that to work. The defaults
+# are 127.0.0.1 and 8080.
+
+# Which port Firetower publishes on this machine. Move it if something else
+# already answers there — Compose would refuse to start rather than share it.
+#
+# Keep the two sides of the tunnel the same number. `-L 8080:127.0.0.1:8080`
+# means the address you type matches FIRETOWER_PUBLIC_URL below, and a
+# forward on a port under 1024 needs root on *your* machine, not this one.
 # HTTP_PORT=8080
-# HTTPS_PORT=8443
+
+# Which interface that port is published on. **Loopback, and leave it there.**
+#
+# This is the control plane. It holds every git token, every agent credential
+# and the root key, so anything that can reach it can erase the codebase of
+# whoever installed this. Setting 0.0.0.0 puts that on the network with a
+# login form as the only thing in front of it, and a host firewall will not
+# save you — Docker writes its own DNAT rules, and they are consulted before
+# the host's INPUT chain, so `ufw deny 8080` does not close a published port.
+#
+# If more than one person needs to reach this, shape 2 is the answer, not this.
+# HTTP_BIND=127.0.0.1
+
+
+# ── Shape 2: reached on a name, over HTTPS ───────────────────────────────────
+#
+# For when a tunnel each is not reasonable — several people, on a network they
+# already share. Caddy terminates TLS in front of Firetower with a certificate
+# **you supply**; see the Caddyfile for where to get one.
+#
+# The name does not have to be reachable from the internet, and it should not
+# be. A private address in DNS is the right answer.
+#
+# Four things, all of them required together:
+#
+#   1. Uncomment COMPOSE_PROFILES and DOMAIN below.
+#   2. Put fullchain.pem and privkey.pem in ./certs beside firetower.yml.
+#      The certificate must cover both `DOMAIN` and `*.DOMAIN` — previews are
+#      served on subdomains, so a bare-name certificate leaves them broken.
+#   3. Point both names at this machine:
+#         firetower.example.com     A   10.0.0.5
+#         *.firetower.example.com   A   10.0.0.5
+#   4. Set FIRETOWER_PREVIEW_DOMAIN and FIRETOWER_PUBLIC_URL, further down.
+#
+# Renewal is yours. Nothing here watches the expiry date; `firetower doctor`
+# warns when there are under three weeks left.
+
+# Creates the `caddy` service. Without this line there is no proxy container
+# at all — which is why shape 1 has nothing to configure.
+# COMPOSE_PROFILES=tls
+
+# The name on the certificate, and the site Caddy answers for. Required with
+# the profile above, and refused if it is missing rather than quietly serving
+# nothing.
+# DOMAIN=firetower.example.com
+
+# Which interface Caddy publishes 443 and 80 on. All of them by default —
+# unlike the control plane, the entire point of this container is that
+# somebody else reaches it. Narrow it to one address, a tailnet for instance,
+# if you have one to narrow it to.
+# HTTPS_BIND=0.0.0.0
+
+
+# ── Both shapes ──────────────────────────────────────────────────────────────
 
 # The address you will open in a browser. Only used for the URL printed on the
 # first start and in notifications — Firetower listens on 4400 inside its
 # container and cannot know what is in front of it.
 #
-# Set this to https://<your DOMAIN> when you set DOMAIN above, or to whatever
-# your own proxy serves when it is the one in front. With no domain and no
-# proxy, the default is right — add the port if you changed HTTP_PORT.
-# FIRETOWER_PUBLIC_URL=https://firetower.example.com
+# Include the port. Over a tunnel the browser is at `localhost:8080`, and a
+# URL that says `localhost` sends whoever clicks a notification to port 80 on
+# their own machine.
+#
+#   shape 1   http://localhost:8080     (the default, with the default port)
+#   shape 2   https://firetower.example.com
+# FIRETOWER_PUBLIC_URL=http://localhost:8080
 
-# The database password. Change it: this container is on a machine with a
-# public address now.
+# What a session's preview hangs off.
+#
+# Leave it alone for shape 1: browsers resolve anything under `.localhost` to
+# 127.0.0.1 with no DNS at all, so previews come through the same tunnel as
+# everything else and need no certificate.
+#
+# For shape 2 set it to DOMAIN — the same name, without the `*.`.
+#
+# **The hostname is the credential.** It carries a signature, and anyone
+# holding one reaches that port of that session without signing in. Treat one
+# like a share link.
+# FIRETOWER_PREVIEW_DOMAIN=firetower.example.com
+
+# The database password. Change it.
 #
 #   openssl rand -base64 24
 POSTGRES_PASSWORD=
@@ -69,8 +140,8 @@ FIRETOWER_ROOT_KEY=
 # Who may use this Firetower.
 #
 # The administrator is created before anything is listening, so there is never
-# a moment where a fresh install on a public address is waiting for whoever
-# finds it first to claim it.
+# a moment where a fresh install is waiting for whoever finds it first to
+# claim it.
 #
 # Leave both empty and one is made anyway, with a password printed once:
 #

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,19 +1,50 @@
-# The front door.
+# TLS, and only TLS.
 #
-# `DOMAIN` unset serves plain HTTP on port 80, reachable from this machine. Set
-# it to a name that resolves here and Caddy gets a certificate on its own,
-# renews it, and redirects 80 to 443 — no configuration beyond the name.
+# This file is read by the `caddy` service, which lives behind the `tls`
+# profile in firetower.yml and is not created without it. If you are reaching
+# Firetower over an ssh tunnel — the default — nothing here applies to you and
+# no proxy is running: the control plane serves its own interface, its own API
+# and its own preview routing.
 #
-# **Expiry warnings.** Let's Encrypt will email before a renewal that has
-# started failing. To get them, add this above the site block:
+# **Where the certificate comes from.** From you. Put two files in `./certs`
+# beside firetower.yml:
 #
-#     {
-#     	email you@example.com
-#     }
+#   certs/fullchain.pem
+#   certs/privkey.pem
 #
-# It is left out rather than wired to a variable because Caddy refuses an empty
-# `email`, and a deployment with no domain has no use for one — a config that
-# will not start is a worse default than a missing warning.
+# Firetower does not ask a certificate authority for one, and that is
+# deliberate. Getting a certificate automatically means answering a challenge
+# on a port the authority can reach, which means putting the control plane on
+# the internet — and the control plane holds every credential Firetower has.
+# Nobody should have to make that trade to get HTTPS on their own network.
+#
+# So mint it wherever your DNS credentials already live — your laptop, your
+# CI, your corporate PKI — and copy the result here. The credential never
+# touches this machine.
+#
+#     certbot certonly --dns-cloudflare \
+#       -d firetower.example.com -d '*.firetower.example.com'
+#
+# **It has to cover both names.** The wildcard is not optional: a session's
+# preview is served at `<session>-<port>-<signature>.{$DOMAIN}`, so a
+# certificate for the bare name alone gives you an interface that works and
+# previews that do not.
+#
+# A wildcard is also the safer shape. Issuing one certificate per preview
+# hostname would publish every one of them to Certificate Transparency logs,
+# which are public and continuously scraped — and a preview hostname *is* the
+# credential for that preview. One wildcard names nothing.
+#
+# **Renewal is yours.** Nothing here watches the expiry date. `firetower
+# doctor` warns when the certificate has less than three weeks left; a
+# `certbot renew` deploy hook that copies the files in and runs
+# `docker compose -f firetower.yml restart caddy` is the usual arrangement.
+#
+# **DNS.** Both names must resolve to this machine from wherever the browsers
+# are. A private address is the right answer and a public one is usually not:
+#
+#   firetower.example.com     A   10.0.0.5
+#   *.firetower.example.com   A   10.0.0.5
 #
 # What this file does not need, and would be wrong to add:
 #
@@ -23,36 +54,12 @@
 #     the event stream arrives as it is written.
 #   * `encode gzip`. It buys little on small JSON and is a way to introduce
 #     buffering on the one stream where that would be felt.
+#   * a separate site block for previews. Firetower routes those itself, on
+#     the `Host` header, before anything else it does. Caddy's job is to
+#     terminate TLS for both names and pass everything through.
 
-# Certificates for preview hostnames are asked for as they are first used,
-# rather than one wildcard certificate obtained up front. That is what keeps
-# this to a DNS record and no provider plugin, no API token and no DNS-01.
-#
-# Firetower is asked before each one, so a name nobody signed never becomes a
-# certificate request — otherwise pointing any domain at this deployment would
-# make it mint them on demand.
-{
-	on_demand_tls {
-		ask http://firetower:4400/preview-known
-	}
-}
+{$DOMAIN}, *.{$DOMAIN} {
+	tls /certs/fullchain.pem /certs/privkey.pem
 
-{$DOMAIN} {
-	reverse_proxy firetower:4400
-}
-
-# The application a session is running, at `<session>-<port>-<signature>`.
-#
-# **With no DOMAIN this block never matches**, and does not need to: the site
-# above is then `:80`, which already answers every hostname — so previews on a
-# laptop work with no DNS, no certificate and nothing configured here at all.
-# The placeholder is a name that resolves nowhere.
-#
-# **With a domain**, set PREVIEW_SITE to `*.your-domain` in `.env` and add one
-# wildcard record pointing there. Nothing else.
-{$PREVIEW_SITE:*.preview.invalid} {
-	tls {
-		on_demand
-	}
 	reverse_proxy firetower:4400
 }

--- a/deploy/cli.json
+++ b/deploy/cli.json
@@ -1,0 +1,4 @@
+{
+  "minimumCli": "0.5.0",
+  "reason": "the compose file publishes the control plane's port itself and puts Caddy behind the `tls` profile; a CLI older than this writes HTTP_PORT onto a service that no longer publishes it, and would create no proxy while promising one"
+}

--- a/deploy/firetower.yml
+++ b/deploy/firetower.yml
@@ -10,11 +10,23 @@
 #
 #   docker compose -f firetower.yml logs firetower
 #
-# **Only Caddy publishes a port.** The control plane holds every credential
-# Firetower has, and is reachable from nothing but the proxy in front of it —
-# which matters more than the certificate does. Which ports Caddy publishes is
-# HTTP_PORT and HTTPS_PORT, and both are pinned to 80 and 443 whenever DOMAIN
-# is set.
+# **The published port is on loopback, and that is the point.** The control
+# plane holds every credential Firetower has — every git token, every agent
+# credential, the root key. Somebody who reaches it can erase the codebase of
+# the company that installed it. So nothing here is published to the internet,
+# and the two shapes below are both ways of reaching it without doing that.
+#
+# **Reached from your own machine**, which is the default and needs nothing at
+# all. Firetower publishes HTTP_PORT on 127.0.0.1, no proxy is created, and an
+# ssh tunnel from wherever you actually sit is the whole story:
+#
+#   ssh -N -L 8080:127.0.0.1:8080 -o ServerAliveInterval=20 you@this-machine
+#
+# **Reached on a name, over HTTPS**, when more than one person uses it and a
+# tunnel each is not reasonable. That turns Caddy on — it is behind the `tls`
+# profile, so it is not created otherwise — and Caddy terminates TLS with a
+# certificate you supply. See the Caddyfile: the name never has to be
+# reachable from the internet, and it should not be.
 #
 # Sessions run in the control plane's own container, the same way they run on a
 # laptop: as a child process, with `localhost` in the fleet. To run them
@@ -31,50 +43,24 @@
 name: firetower
 
 services:
-  # The front door. Without DOMAIN it serves plain HTTP, which is the honest
-  # arrangement for something only ever reached from this machine — and for
-  # something behind a reverse proxy that terminates TLS itself. With one, it
-  # gets a certificate on its own and redirects 80 to 443.
-  caddy:
-    image: caddy:2-alpine
-    restart: unless-stopped
-    depends_on: [firetower]
-    ports:
-      # The host side moves; the container side does not. Caddy is configured
-      # by `{$DOMAIN}`, which names the certificate as well as the address, so
-      # a port belongs out here where changing it means nothing else.
-      #
-      # **Setting DOMAIN pins both of these to 80 and 443.** Let's Encrypt
-      # answers the challenge on those two specifically — HTTP-01 on 80,
-      # TLS-ALPN on 443 — so a certificate cannot be issued anywhere else.
-      # Move them when there is no domain here: either this is reached from
-      # the machine itself, or something else in front already holds 80.
-      - "${HTTP_PORT:-80}:80"
-      # Harmless with no domain: nothing answers there until there is a
-      # certificate to answer with.
-      - "${HTTPS_PORT:-443}:443"
-    environment:
-      DOMAIN: ${DOMAIN:-:80}
-      ACME_EMAIL: ${ACME_EMAIL:-}
-      # Where previews are served. `*.your-domain` when DOMAIN is set, and one
-      # wildcard DNS record pointing here. Left alone with no domain: the site
-      # block above is `:80`, which already answers every hostname, so previews
-      # on `*.localhost` need nothing.
-      PREVIEW_SITE: ${PREVIEW_SITE:-*.preview.invalid}
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      # The certificate and the ACME account key. Lose this and every restart
-      # asks Let's Encrypt for a new certificate — fine twice, rate-limited by
-      # the fifth time, and the limit is measured in days.
-      - caddy_data:/data
-      - caddy_config:/config
-
   firetower:
     image: ghcr.io/firetower-cloud/firetower:latest
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
+    ports:
+      # Loopback unless somebody asks otherwise, because the default has to be
+      # the safe one: a bare `${HTTP_PORT}:4400` would publish the vault on
+      # every interface this machine has, and `ufw deny` would not stop it —
+      # Docker's own DNAT rules are consulted before the host's INPUT chain.
+      #
+      # Reach it with an ssh tunnel. Widening this to 0.0.0.0 is a decision to
+      # put the control plane on the network, and one worth making on purpose.
+      #
+      # With the `tls` profile on, leave this alone: Caddy reaches 4400 over
+      # the network below, not through here.
+      - "${HTTP_BIND:-127.0.0.1}:${HTTP_PORT:-8080}:4400"
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-firetower}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-firetower}
 
@@ -89,26 +75,76 @@ services:
       FIRETOWER_ROOT_KEY: ${FIRETOWER_ROOT_KEY:-}
 
       # The address you actually open, for the URL the log prints on the first
-      # start. This process listens on 4400 in here and has no way to know it
-      # is reached on 443 through Caddy.
-      FIRETOWER_PUBLIC_URL: ${FIRETOWER_PUBLIC_URL:-http://localhost}
+      # start and for the deep link in a notification. This process listens on
+      # 4400 in here and has no way to know what is in front of it.
+      #
+      # The port belongs in here. Over a tunnel the browser is at
+      # `localhost:8080`, and a URL that says `localhost` sends somebody to
+      # port 80 on their own machine.
+      FIRETOWER_PUBLIC_URL: ${FIRETOWER_PUBLIC_URL:-http://localhost:8080}
 
       # What a session's preview hangs off.
       #
       # `localhost` needs nothing: every browser resolves anything under it to
-      # this machine, so a laptop gets previews with no DNS and no certificate.
+      # this machine, so a laptop — or anybody on a tunnel — gets previews with
+      # no DNS and no certificate.
       #
-      # With a domain, set this to it and add `*.that-domain` as a DNS record —
-      # then a preview is a link somebody else can open. **The hostname is the
-      # credential**: it carries a signature, and anyone holding one reaches
-      # that port of that session. Treat one like a share link.
+      # With the `tls` profile on, set this to DOMAIN and add `*.that-domain`
+      # as a DNS record. **The hostname is the credential**: it carries a
+      # signature, and anyone holding one reaches that port of that session.
+      # Treat one like a share link.
       FIRETOWER_PREVIEW_DOMAIN: ${FIRETOWER_PREVIEW_DOMAIN:-localhost}
     volumes:
       # The root key, the token, and everything the worker on this machine
       # keeps: repository mirrors, worktrees, the event log, and the agent's
       # own directory.
       - firetower:/var/lib/firetower
-    # No `ports`. On purpose — see the note at the top.
+
+  # TLS, and only TLS.
+  #
+  # Behind a profile because it is not needed otherwise: the control plane
+  # serves its own interface, its own API and its own preview routing, so with
+  # no certificate to terminate this container would be a pass-through in front
+  # of a server that is already complete. `docker compose up -d` does not
+  # create it. `COMPOSE_PROFILES=tls` — or `--profile tls` — does.
+  #
+  # Turning it on is a commitment to three things: DOMAIN, a certificate at
+  # ./certs, and DNS for both `DOMAIN` and `*.DOMAIN`. The Caddyfile explains
+  # where the certificate comes from.
+  caddy:
+    profiles: [tls]
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on: [firetower]
+    ports:
+      # 0.0.0.0 by default, unlike the control plane above: the entire reason
+      # this container exists is that somebody else has to reach it. Narrow it
+      # to one interface — a tailnet address, say — with HTTPS_BIND.
+      #
+      # Caddy always listens on 443 in here; HTTPS_PORT only moves the host
+      # side, for a machine where something else already holds it.
+      - "${HTTPS_BIND:-0.0.0.0}:${HTTPS_PORT:-443}:443"
+      # Redirects to the address above. Nothing is served here and no
+      # certificate is issued here; drop the line if you would rather nothing
+      # answered on 80 at all.
+      - "${HTTPS_BIND:-0.0.0.0}:80:80"
+    environment:
+      # No default. A Caddyfile whose site address is empty starts and answers
+      # nothing, which looks like a Firetower bug for as long as it takes to
+      # find; refusing is faster to understand than a 404 with no cause.
+      DOMAIN: ${DOMAIN:?set DOMAIN in .env, or turn the tls profile off}
+      # Unused while the certificate is one you supply — there is no authority
+      # to warn you, and expiry is what `firetower doctor` watches instead.
+      # Here for the day Firetower issues its own.
+      ACME_EMAIL: ${ACME_EMAIL:-}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Your certificate and its key. Not optional with this profile on — see
+      # the Caddyfile for how to get one for a name the internet cannot reach,
+      # and for the two files this directory has to contain.
+      - ./certs:/certs:ro
+      - caddy_data:/data
+      - caddy_config:/config
 
   postgres:
     image: postgres:17-alpine
@@ -126,7 +162,7 @@ services:
       interval: 2s
       timeout: 3s
       retries: 30
-    # No `ports` either. Nothing outside this file has any business here.
+    # No `ports`. Nothing outside this file has any business here.
 
 volumes:
   postgres:


### PR DESCRIPTION


---

Part of one change across 2 repositories:
- firetower-cloud/firetower-cli: https://github.com/firetower-cloud/firetower-cli/pull/4
