### PR TITLE
feat: automatic certificates for a private name, via DNS-01

### DIFF
--- a/crates/ft-server/src/lib.rs
+++ b/crates/ft-server/src/lib.rs
@@ -538,12 +538,6 @@ async fn preview_first(
     }
 }
 
-/// What Caddy asks about before requesting a certificate.
-#[derive(serde::Deserialize)]
-struct PreviewAsked {
-    domain: String,
-}
-
 /// Liveness and readiness, deliberately outside the API contract.
 ///
 /// They are for whatever restarts containers, not for the interface, and
@@ -555,33 +549,6 @@ fn operational(state: AppState) -> axum::Router {
     axum::Router::new()
         // Up. Says nothing about whether it can work — that is the other one.
         .route("/healthz", get(|| async { "ok" }))
-        // Whether a hostname is a preview of ours.
-        //
-        // Whether a preview hostname is one we signed.
-        //
-        // **Nothing asks this today.** It was Caddy's `on_demand_tls ask`,
-        // back when a certificate was obtained per preview hostname — which
-        // also meant publishing each one to Certificate Transparency logs,
-        // where a hostname that *is* the credential for that preview does not
-        // belong. The deployment now terminates TLS with one wildcard
-        // certificate and mints nothing on demand.
-        //
-        // Kept because it costs nothing and is the right answer for any future
-        // issuer that needs to ask. Outside the gate because whoever asks has
-        // no credential — and needs none: this answers a question anybody
-        // could answer for themselves by trying the name.
-        .route(
-            "/preview-known",
-            get(
-                |axum::extract::State(state): axum::extract::State<AppState>,
-                 axum::extract::Query(asked): axum::extract::Query<PreviewAsked>| async move {
-                    match state.names.resolve(&asked.domain) {
-                        Some(_) => axum::http::StatusCode::OK,
-                        None => axum::http::StatusCode::NOT_FOUND,
-                    }
-                },
-            ),
-        )
         // Up *and* able to answer. The distinction matters to a load balancer:
         // a control plane whose database has gone should stop being sent
         // requests without being killed and restarted into the same failure.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -54,24 +54,35 @@
 #
 # For when a tunnel each is not reasonable — several people, on a network they
 # already share. Caddy terminates TLS in front of Firetower with a certificate
-# **you supply**; see the Caddyfile for where to get one.
+# it obtains and renews itself.
 #
-# The name does not have to be reachable from the internet, and it should not
-# be. A private address in DNS is the right answer.
+# It does that over the DNS-01 challenge, which proves you control the domain
+# by writing a TXT record through your DNS provider's API. That matters here
+# for one reason: every connection is outbound. The usual challenges work by
+# having Let's Encrypt connect *to this machine*, and a machine Let's Encrypt
+# can reach is a machine anyone can reach — which is the one thing this whole
+# arrangement exists to avoid. So the name does not have to be reachable from
+# the internet, and it should not be. A private address in DNS is right.
 #
-# Four things, all of them required together:
+# Five things, all of them required together:
 #
 #   1. Uncomment COMPOSE_PROFILES and DOMAIN below.
-#   2. Put fullchain.pem and privkey.pem in ./certs beside firetower.yml.
-#      The certificate must cover both `DOMAIN` and `*.DOMAIN` — previews are
-#      served on subdomains, so a bare-name certificate leaves them broken.
+#   2. Set DNS_PROVIDER and DNS_API_TOKEN below.
 #   3. Point both names at this machine:
 #         firetower.example.com     A   10.0.0.5
 #         *.firetower.example.com   A   10.0.0.5
+#      The wildcard is not optional — previews are served on subdomains, and
+#      it is also what keeps every preview hostname out of the public
+#      Certificate Transparency logs.
 #   4. Set FIRETOWER_PREVIEW_DOMAIN and FIRETOWER_PUBLIC_URL, further down.
+#   5. Start as usual. The first `up -d` compiles Caddy and takes a few
+#      minutes rather than seconds — see DNS_PROVIDER below. Later, changing
+#      DNS_PROVIDER or DNS_MODULE_VERSION needs `up -d --build` to be picked
+#      up; without it the image already on this machine is reused.
 #
-# Renewal is yours. Nothing here watches the expiry date; `firetower doctor`
-# warns when there are under three weeks left.
+# Renewal is Caddy's, at about two-thirds of the certificate's life, with
+# nothing for you to run. `firetower doctor` still reports what it can see of
+# the expiry.
 
 # Creates the `caddy` service. Without this line there is no proxy container
 # at all — which is why shape 1 has nothing to configure.
@@ -81,6 +92,66 @@
 # the profile above, and refused if it is missing rather than quietly serving
 # nothing.
 # DOMAIN=firetower.example.com
+
+# Which DNS provider the domain above is behind, as the name of its module at
+# https://github.com/caddy-dns — `cloudflare`, `digitalocean`, `hetzner`,
+# `desec`, `gandi`, `vultr`, `linode` and many more.
+#
+# **This is compiled into Caddy**, because that is how Caddy resolves DNS
+# providers, so the first `up -d` pulls a Go toolchain and takes a few minutes
+# rather than seconds. It is cached afterwards. It also needs the
+# network at that moment, and specifically a working Go module proxy.
+#
+# Providers that want more than one value — Route 53, Azure, Google Cloud —
+# cannot be written as the one line this generates. Set DNS_PROVIDER to the
+# module name anyway, so the right module is built in, and write the provider
+# block by hand in the Caddyfile; `firetower upgrade` does not touch that file.
+#
+# Set it to `none` if you would rather supply your own certificate, from a
+# corporate CA or a provider with no module here. The Caddyfile has that path
+# commented, and it is two lines.
+# DNS_PROVIDER=cloudflare
+
+# A credential for that provider's API, scoped to editing records in the one
+# zone your domain is in if the provider lets you say that.
+#
+# Caddy reads it from the environment at run time, so it is never written into
+# a config file and never baked into the image. It is still plaintext on disk
+# here, and visible in `docker compose config`.
+#
+# Required with the profile on, unless DNS_PROVIDER=none. Caddy refuses to
+# start without it and says so, rather than starting and serving a name it can
+# get no certificate for.
+# DNS_API_TOKEN=
+
+# Optional: pin the provider module to a version, so that two installs a month
+# apart are the same binary. Empty takes the module's default branch on the day
+# it is built, which is a real difference — the same DNS_PROVIDER built weeks
+# apart gave v0.2.1 and v0.2.4 here.
+#
+# Versions are the module's own, not Caddy's, so the tag to use is whatever
+# that provider's repository under https://github.com/caddy-dns publishes.
+# `docker compose -f firetower.yml exec caddy caddy build-info` prints the one
+# in the image now.
+# DNS_MODULE_VERSION=v0.2.4
+
+# Optional: substitute a Go module while building Caddy, `old=new@version`.
+#
+# Building from source means a provider module can be held back by something it
+# depends on rather than by anything in it. A caddy-dns module still pinning a
+# `libdns/*` from before its v1 interface does not compile against a current
+# Caddy — and until its maintainer tags a release there is otherwise nothing to
+# do but wait. This is the way past it:
+#
+#   DNS_MODULE_REPLACE=github.com/libdns/vercel=github.com/libdns/vercel@v0.1.0
+#
+# Nothing validates it. A wrong value fails the build, which is where a missing
+# one fails too.
+# DNS_MODULE_REPLACE=
+
+# Optional: where Let's Encrypt writes about an expiry that got past Caddy's
+# own renewal. Issuance works without it.
+# ACME_EMAIL=ops@example.com
 
 # Which interface Caddy publishes 443 and 80 on. All of them by default —
 # unlike the control plane, the entire point of this container is that

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -6,45 +6,60 @@
 # no proxy is running: the control plane serves its own interface, its own API
 # and its own preview routing.
 #
-# **Where the certificate comes from.** From you. Put two files in `./certs`
-# beside firetower.yml:
+# **Where the certificate comes from.** Caddy asks Let's Encrypt for it, and
+# renews it, without this machine being reachable from the internet.
 #
-#   certs/fullchain.pem
-#   certs/privkey.pem
+# That combination is the whole point, and it is why the challenge below is
+# the one it is. HTTP-01 and TLS-ALPN-01 — the usual two — work by having the
+# authority open a connection *to us*, and a machine Let's Encrypt can reach
+# is a machine anyone can reach. This one holds every git token, every agent
+# credential and the root key, so that is not a trade worth making for a
+# padlock.
 #
-# Firetower does not ask a certificate authority for one, and that is
-# deliberate. Getting a certificate automatically means answering a challenge
-# on a port the authority can reach, which means putting the control plane on
-# the internet — and the control plane holds every credential Firetower has.
-# Nobody should have to make that trade to get HTTPS on their own network.
+# DNS-01 proves control the other way round: Caddy writes a TXT record through
+# your DNS provider's API and the authority reads it back out of DNS. Every
+# connection Caddy makes is outbound. The name is free to resolve to 10.0.0.5
+# and answer nobody outside your network, which is what it should do.
 #
-# So mint it wherever your DNS credentials already live — your laptop, your
-# CI, your corporate PKI — and copy the result here. The credential never
-# touches this machine.
-#
-#     certbot certonly --dns-cloudflare \
-#       -d firetower.example.com -d '*.firetower.example.com'
-#
-# **It has to cover both names.** The wildcard is not optional: a session's
-# preview is served at `<session>-<port>-<signature>.{$DOMAIN}`, so a
-# certificate for the bare name alone gives you an interface that works and
-# previews that do not.
+# **It has to cover both names, and DNS-01 is also the only challenge that can
+# do that.** A session's preview is served at
+# `<session>-<port>-<signature>.{$DOMAIN}`, so a certificate for the bare name
+# alone gives you an interface that works and previews that do not.
 #
 # A wildcard is also the safer shape. Issuing one certificate per preview
 # hostname would publish every one of them to Certificate Transparency logs,
 # which are public and continuously scraped — and a preview hostname *is* the
 # credential for that preview. One wildcard names nothing.
 #
-# **Renewal is yours.** Nothing here watches the expiry date. `firetower
-# doctor` warns when the certificate has less than three weeks left; a
-# `certbot renew` deploy hook that copies the files in and runs
-# `docker compose -f firetower.yml restart caddy` is the usual arrangement.
+# **What you have to give it.** Two values in .env:
+#
+#   DNS_PROVIDER    which provider module to compile into Caddy — see
+#                   Caddyfile.dockerfile, and https://github.com/caddy-dns
+#   DNS_API_TOKEN   a credential for that provider's API
+#
+# Scope the token to editing records in the one zone this domain is in, if
+# your provider lets you say that. It lives in .env on this machine and Caddy
+# reads it from the environment at run time — it is never written into this
+# file, and it is not in `docker compose config` output the way a build
+# argument would be.
+#
+# **Renewal is Caddy's.** It renews at about two-thirds of the certificate's
+# life, unattended, and `firetower doctor` reports the expiry it can see. The
+# certificate and the ACME account key live in the `caddy_data` volume:
+# keeping that volume across upgrades is what stops every restart from being a
+# fresh issuance, and Let's Encrypt's duplicate-certificate limit is five a
+# week.
 #
 # **DNS.** Both names must resolve to this machine from wherever the browsers
 # are. A private address is the right answer and a public one is usually not:
 #
 #   firetower.example.com     A   10.0.0.5
 #   *.firetower.example.com   A   10.0.0.5
+#
+# The wildcard record is what previews resolve through. The wildcard
+# *certificate* is a separate thing and comes from the block below — having
+# one without the other gives you previews that resolve and do not verify, or
+# verify and do not resolve.
 #
 # What this file does not need, and would be wrong to add:
 #
@@ -57,9 +72,38 @@
 #   * a separate site block for previews. Firetower routes those itself, on
 #     the `Host` header, before anything else it does. Caddy's job is to
 #     terminate TLS for both names and pass everything through.
+#   * `on_demand_tls`. It is what this replaces. A certificate per preview
+#     hostname is the Certificate Transparency problem described above.
+{
+	# Where Let's Encrypt writes about an expiry Caddy somehow did not handle.
+	# Optional, and quoted so that leaving it empty is not a parse error.
+	email "{$ACME_EMAIL}"
+}
 
 {$DOMAIN}, *.{$DOMAIN} {
-	tls /certs/fullchain.pem /certs/privkey.pem
+	# DNS_PROVIDER is substituted before this file is parsed, because Caddy has
+	# to resolve the module by name at that point — it is the module compiled
+	# in by Caddyfile.dockerfile, and the two must agree. DNS_API_TOKEN is read
+	# from the environment at run time instead, which is where a secret should
+	# be resolved.
+	tls {
+		dns {$DNS_PROVIDER} {env.DNS_API_TOKEN}
+	}
+
+	# Bring your own certificate instead — for a corporate CA, a provider with
+	# no Caddy module, or a machine that cannot reach a Go module proxy to
+	# build one. Set DNS_PROVIDER=none in .env, comment out the three-line
+	# `tls` block above, uncomment the one below, and put fullchain.pem and
+	# privkey.pem in ./certs beside firetower.yml. Renewal is yours again if
+	# you do.
+	#
+	#     certbot certonly --dns-cloudflare \
+	#       -d firetower.example.com -d '*.firetower.example.com'
+	#
+	# Edits here survive `firetower upgrade`, which rewrites firetower.yml and
+	# leaves this file alone.
+	#
+	# tls /certs/fullchain.pem /certs/privkey.pem
 
 	reverse_proxy firetower:4400
 }

--- a/deploy/Caddyfile.dockerfile
+++ b/deploy/Caddyfile.dockerfile
@@ -1,0 +1,187 @@
+# The Caddy that the `tls` profile runs, with one DNS provider compiled in.
+#
+# Caddy resolves DNS providers as compiled-in modules, and `caddy:2-alpine`
+# ships none of them. Obtaining a certificate over DNS-01 — the only challenge
+# that needs no inbound path to this machine, and the only one that can issue
+# a wildcard — therefore needs a Caddy built with the module for whatever your
+# domain's DNS is behind. That is all this file does: add one module to the
+# stock Caddy, and keep the stock image underneath it.
+#
+# Nothing here runs on the default install. The `caddy` service is behind the
+# `tls` profile, so `docker compose -f firetower.yml up -d` creates no proxy
+# and builds no image; shape 1 is untouched by all of this.
+#
+# **The first build is slow, and that is the whole cost of this approach.** It
+# pulls `caddy:2-builder` — a Go toolchain, around 390 MB against the 89 MB of
+# the image it produces — and compiles Caddy from source: a few minutes, once.
+# It is cached afterwards, so later `up -d --build` runs are immediate until
+# DNS_MODULE or DNS_MODULE_VERSION changes.
+#
+# **It needs the network at install time**, and specifically a working Go
+# module proxy. A machine that cannot reach proxy.golang.org cannot build
+# this — and a machine in that state generally cannot reach GitHub either, so
+# it is the same machine that falls back to a pinned CLI release.
+#
+# DNS_PROVIDER=none skips the compile but not the pull: the builder image is
+# still fetched, because the stage below is what the final image copies from
+# either way. So an air-gapped machine has one more image to load by hand than
+# it used to, on top of the ones it was already loading. Everything else about
+# that path is unchanged — supply your own certificate, and uncomment the
+# `tls` line in the Caddyfile.
+
+# Which provider module to compile in, as Compose passes it from DNS_PROVIDER:
+#
+#   cloudflare                    →  github.com/caddy-dns/cloudflare
+#   github.com/libdns/something   →  taken as written, for a module that does
+#                                    not live under caddy-dns
+#   none                          →  no module; the stock Caddy, for the
+#                                    bring-your-own-certificate path
+ARG DNS_MODULE
+
+# Which version of it, and empty is a real answer with a real cost: the build
+# takes whatever the module's default branch is on the day it runs, so the
+# same .env a month apart is not the same binary. Pin it — `v1.1.0`, or a
+# commit — if you would rather two installs match.
+ARG DNS_MODULE_VERSION
+
+# A Go module to substitute while building, `old=new@version`.
+#
+# The escape hatch for building from source, which is that a provider module can
+# be broken by something it depends on rather than by anything in it. A caddy-dns
+# module pinning a `libdns/*` from before the v1 `Record` interface does not
+# compile against a current Caddy at all, and until its maintainer tags a
+# release there is otherwise nothing an operator can do but wait.
+#
+#     DNS_MODULE_REPLACE=github.com/libdns/vercel=github.com/libdns/vercel@v0.1.0
+#
+# Passed straight to `xcaddy --replace`. Nothing validates it: a wrong value
+# fails the build, which is the same place a missing one fails.
+ARG DNS_MODULE_REPLACE
+
+# Where `none` gets a Caddy from. `caddy:2-builder` carries the Go toolchain
+# and xcaddy but no caddy binary of its own, so without this stage the
+# no-module path would have to compile a stock Caddy to produce a file that
+# already exists one line below.
+FROM caddy:2-alpine AS stock
+
+FROM caddy:2-builder AS builder
+
+# Re-declared because a global ARG is not in scope inside a stage. Leaving
+# these out does not fail the build — it substitutes an empty string, and the
+# image comes out with no module and no complaint.
+ARG DNS_MODULE
+ARG DNS_MODULE_VERSION
+ARG DNS_MODULE_REPLACE
+
+COPY --from=stock /usr/bin/caddy /usr/bin/caddy
+
+# xcaddy writes ./caddy, and this image's WORKDIR is /usr/bin — so a build
+# replaces the binary copied in above, and `none` leaves it as it is.
+#
+# The Caddy version is not chosen here. `caddy:2-builder` sets CADDY_VERSION,
+# xcaddy honours it, and it is the same version as the `caddy:2-alpine` this
+# ends up on top of. Keep those two tags in step.
+RUN set -eu; \
+	case "${DNS_MODULE}" in \
+	"" | none) \
+		echo "DNS_PROVIDER=none — keeping the stock Caddy, with no DNS provider."; \
+		exit 0 ;; \
+	*/*) module="${DNS_MODULE}" ;; \
+	*) module="github.com/caddy-dns/${DNS_MODULE}" ;; \
+	esac; \
+	if [ -n "${DNS_MODULE_REPLACE:-}" ]; then \
+		set -- --replace "${DNS_MODULE_REPLACE}"; \
+	else \
+		set --; \
+	fi; \
+	xcaddy build --with "${module}${DNS_MODULE_VERSION:+@${DNS_MODULE_VERSION}}" "$@"
+
+FROM caddy:2-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# Where "you have not set DOMAIN" is caught, and the reason it is caught here
+# rather than in firetower.yml.
+#
+# The obvious place is a Compose `${DOMAIN:?...}` guard, and that is what the
+# `tls` service used to carry. It cannot stay there: Compose interpolates
+# every service in the file before it works out which profiles are on, so a
+# required-variable guard inside a profile fires even when that profile is
+# off. One `${DOMAIN:?}` on this container is enough to stop
+# `docker compose up -d` on the default install — the one that never creates
+# this container at all. `--profile` does not change it, and neither does the
+# no-colon `${DOMAIN?}` form; both were checked.
+#
+# So the values arrive with empty defaults and are checked here instead, which
+# runs only when this container does — that is, only with the profile on. The
+# message is better for it, too: it names everything that is missing at once
+# rather than the first one Compose happened to interpolate.
+COPY <<'SCRIPT' /usr/local/bin/firetower-caddy-preflight
+#!/bin/sh
+# Refuse a half-configured `tls` profile, rather than starting and serving
+# something that cannot work. See firetower.yml and .env.example.
+set -eu
+
+# What is required is read out of the Caddyfile rather than assumed, because
+# only the Caddyfile knows. Three shapes run through this same image:
+#
+#   * one token          `dns {$DNS_PROVIDER} {env.DNS_API_TOKEN}`
+#   * a provider block   `dns {$DNS_PROVIDER} { … }` — route53, Azure and the
+#                        rest, which take several values and no single token
+#   * your own cert      the `dns` line commented out entirely
+#
+# Demanding DNS_API_TOKEN of the second two would refuse a correct deployment,
+# and the earlier version of this did exactly that. Asking the file keeps the
+# question and the answer in the same place.
+CADDYFILE=/etc/caddy/Caddyfile
+uses() { grep -q "$1" "$CADDYFILE" 2>/dev/null; }
+
+missing=""
+uses '{\$DOMAIN}' && [ -z "${DOMAIN:-}" ] && missing="${missing}
+  DOMAIN         the name this answers for, e.g. firetower.example.com"
+uses '{\$DNS_PROVIDER}' && [ -z "${DNS_PROVIDER:-}" ] && missing="${missing}
+  DNS_PROVIDER   the github.com/caddy-dns module for your DNS, e.g.
+                 cloudflare — or \`none\` if you supply your own certificate"
+uses 'env\.DNS_API_TOKEN' && [ -z "${DNS_API_TOKEN:-}" ] && missing="${missing}
+  DNS_API_TOKEN  a credential for that provider's API"
+
+# `set -eu` would end the script on the last `uses` returning false.
+true
+
+if [ -n "$missing" ]; then
+	cat >&2 <<MESSAGE
+Firetower's \`tls\` profile is on, and this is not set in .env:
+${missing}
+
+Caddy obtains the certificate itself over DNS-01 and needs those to do it.
+Set them beside firetower.yml and start again with:
+
+  docker compose -f firetower.yml up -d
+
+Turning the profile off — removing COMPOSE_PROFILES=tls — goes back to
+reaching Firetower over an ssh tunnel, which needs none of this.
+MESSAGE
+	exit 1
+fi
+
+# Nothing to run means the CMD went missing — see the note by ENTRYPOINT.
+# Without this the script would simply end, successfully, having started no
+# Caddy at all.
+if [ "$#" -eq 0 ]; then
+	echo "firetower: no command to run — the image is built wrong." >&2
+	exit 1
+fi
+
+exec "$@"
+SCRIPT
+RUN chmod +x /usr/local/bin/firetower-caddy-preflight
+
+# The base image has no entrypoint and puts the whole command in CMD — and
+# setting an ENTRYPOINT here resets that CMD to null, so it has to be written
+# out again. Leaving it off is not an error anybody sees: the entrypoint gets
+# no arguments, `exec "$@"` execs nothing, the script falls off the end with
+# status 0, and `restart: unless-stopped` turns that into a container that
+# restarts for ever, logs not one line, and never starts Caddy.
+#
+# Keep this in step with `caddy:2-alpine`'s own CMD if upstream changes it.
+ENTRYPOINT ["/usr/local/bin/firetower-caddy-preflight"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/deploy/cli.json
+++ b/deploy/cli.json
@@ -1,4 +1,4 @@
 {
-  "minimumCli": "0.6.0",
-  "reason": "this release re-purposes HTTP_PORT — it was Caddy's host port and is now the control plane's — and moves Caddy behind the `tls` profile. A CLI older than this carries the old value forward on upgrade, so the control plane inherits a port that described something else, and the Caddy it is replacing stays up holding it."
+  "minimumCli": "0.9.0",
+  "reason": "the `tls` profile now builds Caddy rather than pulling it, so that a DNS provider module is compiled in and the certificate can be obtained and renewed over DNS-01. An older CLI does not fetch Caddyfile.dockerfile, so `up` fails with a missing dockerfile; does not write DNS_PROVIDER, DNS_API_TOKEN or DNS_MODULE_REPLACE, so Caddy refuses to start; writes the single-token `dns` line for every provider, which is a parse error for the ones that take several values; and runs a bare `docker compose pull`, which exits non-zero on a service that is built rather than pulled."
 }

--- a/deploy/firetower.yml
+++ b/deploy/firetower.yml
@@ -2,9 +2,13 @@
 #
 #   curl -O https://raw.githubusercontent.com/firetower-cloud/firetower/main/deploy/firetower.yml
 #   curl -O https://raw.githubusercontent.com/firetower-cloud/firetower/main/deploy/Caddyfile
+#   curl -O https://raw.githubusercontent.com/firetower-cloud/firetower/main/deploy/Caddyfile.dockerfile
 #   curl -o .env https://raw.githubusercontent.com/firetower-cloud/firetower/main/deploy/.env.example
 #   # edit .env
 #   docker compose -f firetower.yml up -d
+#
+# The last two of those are only read with the `tls` profile on, and that
+# start becomes `up -d --build` — see the `caddy` service.
 #
 # Then read the log: the first start prints an administrator to sign in as.
 #
@@ -24,9 +28,11 @@
 #
 # **Reached on a name, over HTTPS**, when more than one person uses it and a
 # tunnel each is not reasonable. That turns Caddy on — it is behind the `tls`
-# profile, so it is not created otherwise — and Caddy terminates TLS with a
-# certificate you supply. See the Caddyfile: the name never has to be
-# reachable from the internet, and it should not be.
+# profile, so it is not created otherwise — and Caddy obtains a certificate
+# for the name, and renews it, on its own. It does that over DNS-01, which
+# proves control by writing a record through your DNS provider's API rather
+# than by answering a connection: the name never has to be reachable from the
+# internet, and it should not be. See the Caddyfile.
 #
 # Sessions run in the control plane's own container, the same way they run on a
 # laptop: as a child process, with `localhost` in the fleet. To run them
@@ -108,12 +114,42 @@ services:
   # of a server that is already complete. `docker compose up -d` does not
   # create it. `COMPOSE_PROFILES=tls` — or `--profile tls` — does.
   #
-  # Turning it on is a commitment to three things: DOMAIN, a certificate at
-  # ./certs, and DNS for both `DOMAIN` and `*.DOMAIN`. The Caddyfile explains
-  # where the certificate comes from.
+  # Turning it on is a commitment to three things: DOMAIN, DNS credentials for
+  # it, and A records for both `DOMAIN` and `*.DOMAIN`. Caddy obtains the
+  # certificate itself over DNS-01 and renews it unattended — which it can do
+  # without this machine ever being reachable from the internet, because the
+  # challenge is answered by writing a TXT record outbound rather than by
+  # answering a connection inbound. The Caddyfile explains the whole shape,
+  # including how to supply your own certificate instead.
   caddy:
     profiles: [tls]
-    image: caddy:2-alpine
+    # Built, not pulled. Caddy resolves DNS providers as compiled-in modules
+    # and `caddy:2-alpine` ships none of them, so the module for your DNS has
+    # to be baked in — see Caddyfile.dockerfile, which is where the cost of
+    # this lives: the first build pulls a Go toolchain and takes a few
+    # minutes. Nothing builds without the profile above.
+    #
+    # `up -d` builds this on its own the first time, because there is no
+    # image yet. It does not build again afterwards — so changing
+    # DNS_PROVIDER or DNS_MODULE_VERSION later needs `up -d --build`, or the
+    # image already here is reused and the change does nothing visible.
+    build:
+      context: .
+      dockerfile: Caddyfile.dockerfile
+      args:
+        # Empty, or `none`, builds a stock Caddy with no provider in it —
+        # which is the bring-your-own-certificate path in the Caddyfile.
+        DNS_MODULE: ${DNS_PROVIDER:-}
+        # Optional. Empty builds whatever the module's default branch is
+        # today, so the same .env a month apart is not the same binary.
+        DNS_MODULE_VERSION: ${DNS_MODULE_VERSION:-}
+        # Optional. `old=new@version`, for a provider module held back by
+        # something it depends on rather than by anything in it. See
+        # Caddyfile.dockerfile.
+        DNS_MODULE_REPLACE: ${DNS_MODULE_REPLACE:-}
+    # Named, so that the build does not overwrite the `caddy:2-alpine` tag
+    # this machine may be holding for something else.
+    image: firetower-caddy
     restart: unless-stopped
     depends_on: [firetower]
     ports:
@@ -125,26 +161,53 @@ services:
       # side, for a machine where something else already holds it.
       - "${HTTPS_BIND:-0.0.0.0}:${HTTPS_PORT:-443}:443"
       # Redirects to the address above. Nothing is served here and no
-      # certificate is issued here; drop the line if you would rather nothing
-      # answered on 80 at all.
+      # certificate is issued here — DNS-01 needs no inbound port at all, which
+      # is the reason it is the challenge in use; drop the line if you would
+      # rather nothing answered on 80.
       - "${HTTPS_BIND:-0.0.0.0}:80:80"
     environment:
-      # No default. A Caddyfile whose site address is empty starts and answers
-      # nothing, which looks like a Firetower bug for as long as it takes to
-      # find; refusing is faster to understand than a 404 with no cause.
-      DOMAIN: ${DOMAIN:?set DOMAIN in .env, or turn the tls profile off}
-      # Unused while the certificate is one you supply — there is no authority
-      # to warn you, and expiry is what `firetower doctor` watches instead.
-      # Here for the day Firetower issues its own.
+      # Empty defaults, and every one of these is in fact required — the
+      # image refuses to start without them, and says which are missing.
+      #
+      # They are not `${DOMAIN:?...}` guards, which is where this check used
+      # to live and is the obvious place for it, because Compose interpolates
+      # the whole file before it decides which profiles are on. A required
+      # variable inside a profile therefore fires with the profile off: one
+      # `:?` here is enough to stop `docker compose up -d` on the default
+      # install, which never creates this container at all. Neither
+      # `--profile` nor the no-colon `${DOMAIN?}` form avoids it.
+      #
+      # So the refusing happens in the entrypoint, which runs only when this
+      # container does. See Caddyfile.dockerfile.
+
+      # The name Caddy answers for, and the name on the certificate.
+      DOMAIN: ${DOMAIN:-}
+
+      # The same value the module above was built from, and it has to match:
+      # the Caddyfile substitutes it before parsing, and names a module that
+      # is either compiled in or is not.
+      DNS_PROVIDER: ${DNS_PROVIDER:-}
+
+      # The credential Caddy writes the challenge record with. Read from the
+      # environment by the Caddyfile at run time, so it is never written into
+      # a config file — and, unlike the build argument above, not baked into
+      # an image layer. Unread when DNS_PROVIDER=none.
+      DNS_API_TOKEN: ${DNS_API_TOKEN:-}
+
+      # Where Let's Encrypt writes about an expiry that somehow got past
+      # Caddy's own renewal. Optional — issuance works without it, and there
+      # is nothing to notify at all on the bring-your-own-certificate path.
       ACME_EMAIL: ${ACME_EMAIL:-}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      # Your certificate and its key. Not optional with this profile on — see
-      # the Caddyfile for how to get one for a name the internet cannot reach,
-      # and for the two files this directory has to contain.
-      - ./certs:/certs:ro
+      # The certificate, the key, and the ACME account. **Keep this volume.**
+      # Losing it is a fresh issuance on the next start, and Let's Encrypt
+      # allows five duplicate certificates a week.
       - caddy_data:/data
       - caddy_config:/config
+      # Only for the bring-your-own-certificate path in the Caddyfile. Empty
+      # and unread otherwise; Docker creates the directory if it is missing.
+      - ./certs:/certs:ro
 
   postgres:
     image: postgres:17-alpine


### PR DESCRIPTION
Firetower can now obtain and renew TLS certificates automatically using the DNS-01 ACME challenge, eliminating the need for manual certificate renewal on private domains. The implementation compiles a DNS provider module into Caddy at deployment time, allowing outbound-only communication with Let's Encrypt via DNS record validation.

The change adds a `firetower domain` command to configure domain settings for existing deployments, and supports 90+ DNS providers through the caddy-dns ecosystem. Wildcard certificates are issued automatically, keeping preview hostnames out of Certificate Transparency logs. The system validates provider names at CLI time and provides helpful error messages for typos. Migration includes a database schema fix for workspace share field casing and removal of the obsolete `on_demand_tls` endpoint.

Closes #49

---

Part of one change across 3 repositories:
- firetower-cloud/firetower-cli: https://github.com/firetower-cloud/firetower-cli/pull/12
- firetower-cloud/firetower-website: https://github.com/firetower-cloud/firetower-website/pull/1
