### PR TITLE
feat: mobile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /target
 /api/openapi.json.tmp
 node_modules
+# pnpm puts its store here when it cannot use the one in $HOME — which is what
+# happens running the compose stack, where $HOME is the container's. It is a
+# cache of every package ever downloaded, so it is large, and it is not ours.
+/.pnpm-store
 .next
 # The static export. Built by `just build` and compiled into the binary, so
 # nothing in it belongs in version control. The directory has to exist for

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,19 @@
+# For file watchers, not for git — read by the `ignore` crate, which is what
+# `cargo watch` in `just dev` uses to decide what a change is.
+#
+# It normally gets this from `.gitignore`, and here it cannot: this checkout is
+# a git *worktree*, so `.git` is a file pointing elsewhere rather than a
+# directory, and the crate finds no repository to read ignores from. With
+# nothing ignored, two things inside the tree restart the control plane about
+# twice a second, for ever:
+#
+#   * `web/.next`, which Turbopack writes to continuously — the web half has
+#     its own watcher and the Rust one has no business reacting to it;
+#   * `.firetower/`, which is FIRETOWER_HOME in the compose stack, so the
+#     control plane's own state files restart the control plane.
+#
+# Untracked and local to this checkout.
+web/
+.firetower/
+target/
+.pnpm-store/

--- a/web/app/configuration/page.tsx
+++ b/web/app/configuration/page.tsx
@@ -49,7 +49,7 @@ export default function Configuration() {
   }, []);
 
   return (
-    <div className="px-8 pt-6 pb-24">
+    <div className="px-4 pt-5 pb-24 md:px-8 md:pt-6">
       {/* No heading of its own: each section brings one, and two stacked
           headings saying the same word is the page apologising for existing. */}
       <nav className="mb-2 flex gap-1 border-b border-line">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -41,6 +41,13 @@
   --text-micro--line-height: 1.4;
   --text-code: 0.8125rem; /* 13px — what the machine said */
   --text-code--line-height: 1.6;
+  /* 16px — the floor for anything you type into, on a touch screen.
+     Not a seventh voice: it is `--text-ui` with a minimum. Under 16px iOS
+     zooms the page when a field takes focus and never zooms back out, which
+     is half of what reads as "the app zoomed by itself". Used below `md` and
+     nowhere else, so the desk keeps the 13px it was designed at. */
+  --text-input: 1rem;
+  --text-input--line-height: 1.5;
 
   /* ── Signals ────────────────────────────────────────────────
      Semantic only. Ember answers one question — is something waiting on you —
@@ -127,6 +134,16 @@
   :focus-visible {
     outline: 1px solid var(--color-bone);
     outline-offset: 2px;
+  }
+
+  /* Double-tap does not zoom, anywhere.
+     `manipulation` is `auto` minus double-tap-to-zoom, which also takes the
+     300ms wait that browsers hold every tap for in case a second one is
+     coming. Pinch is still allowed here — that is decided per surface, on
+     `.no-zoom` below, because a page of prose has no reason to fight the
+     browser and the workbench has every reason. */
+  body {
+    touch-action: manipulation;
   }
 
   /* The standard properties, not only the WebKit pseudo-elements: with
@@ -217,6 +234,43 @@
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-raise);
   }
+
+  /* ── Touch: the workbench is a surface, not a document ──────
+     Chat, diff, files, ship. Scrolling, dragging and tapping surfaces, where
+     a pinch is a fumbled scroll and the page ending up at 1.4× with the
+     composer off the right edge is a bug rather than a preference.
+
+     `pan-x pan-y` allows both scroll directions and refuses the pinch, which
+     is the whole of it in every browser except Safari — Safari has ignored
+     `user-scalable=no` for pinch since iOS 10, deliberately, and honours
+     `touch-action` for scrolling but not for its own gesture recognisers.
+     The JavaScript half of this lives in `useNoZoom`; neither half works
+     alone.
+
+     Deliberately *not* on `body`. Tasks, Configuration, login and setup are
+     documents and keep pinch, because taking zoom away from a page of prose
+     is taking away an accessibility feature to solve a problem that page does
+     not have. The diff gets a size control instead — see `DiffTab`. */
+  .no-zoom {
+    touch-action: pan-x pan-y;
+  }
+
+  /* ── There is no `.safe-bottom` here, on purpose ─────────────
+     `viewport-fit: cover` draws under the notch and the home indicator, so
+     everything resting on an edge has to say how far in that edge really is.
+     The obvious way to write that is a class — and a class in this layer loses
+     to any `pb-*` sitting beside it on the same element, because a *layer*
+     beats specificity and utilities come after components. It does not warn;
+     it just silently does nothing, which it did in three places before this
+     comment replaced it.
+
+     So the insets are written as ordinary utilities at the point of use —
+     `pb-[max(1rem,env(safe-area-inset-bottom))]` — which compose with
+     `sm:pb-3` the way every other padding in the app does. The one rule that
+     genuinely cannot be a utility, because it has to reach forty fields that
+     do not know about it, is at the foot of this file and is outside every
+     layer for the same reason. */
+
 }
 
 /* ── The one loud thing: an agent waiting on you ───────────── */
@@ -377,5 +431,44 @@
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
+  }
+}
+
+/* ── Anything you type into is at least 16px, on a touch screen ──
+   Under 16px, iOS zooms the page in when a field takes focus and does not
+   zoom back out. Half of what reads as "the app zoomed by itself" is this
+   rather than a pinch, and it is the composer — the field everybody touches —
+   that provokes it.
+
+   ## Why this is here rather than a class on each field
+
+   Two reasons, and the second is the one that decided it.
+
+   There are forty of them. A rule per field is forty chances to add the
+   forty-first without it, and nothing that would ever say so.
+
+   And a class would not work. Tailwind's layer order is
+   `theme, base, components, utilities`, and a *layer* beats specificity — so
+   `.type-into` in `@layer components` loses to the `text-body` sitting beside
+   it on the same element, however specific it is. Putting it in `@layer
+   utilities` would work only by being later in the file than the generated
+   utilities, which is true today and is not a thing to depend on.
+
+   Declarations outside every layer take precedence over layered ones, whatever
+   their specificity. So this element selector beats `.text-meta` without
+   fighting it, and does so by a rule the cascade guarantees rather than by
+   source order.
+
+   Above `md` none of it applies and the type scale is untouched: there is no
+   soft keyboard to provoke, and 13px is what the interface is drawn at.
+
+   `font-size` only. Line height belongs to the size the element was given —
+   a message box and a one-line field want different ones, and this knows
+   nothing about which it is looking at. */
+@media (width < 48rem) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+  textarea,
+  select {
+    font-size: var(--text-input);
   }
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Shell } from "@/components/Shell";
@@ -38,6 +38,37 @@ const jetbrains = localFont({
 export const metadata: Metadata = {
   title: "Firetower",
   description: "Run any coding agent, on your own servers, from anywhere.",
+};
+
+/**
+ * How the page meets the device it is on.
+ *
+ * There was none of this, so the page took the default and a phone could
+ * pinch the workbench to 1.4× and leave the composer off the right edge.
+ *
+ * `maximumScale` and `userScalable` are the half of that fix browsers agree
+ * on; Safari has ignored them for pinch since iOS 10, on accessibility
+ * grounds, which is why there is a `.no-zoom` rule and a `useNoZoom` hook as
+ * well and why the two of them are scoped to the workbench rather than
+ * applied here. What this *does* buy on every browser is the other half of
+ * the complaint: a field under 16px no longer zooms the page when it takes
+ * focus.
+ *
+ * `viewportFit: "cover"` draws under the notch and the home indicator, which
+ * is only correct because everything resting on the floor pads itself with
+ * `env(safe-area-inset-bottom)` — see `.safe-bottom`.
+ *
+ * `interactiveWidget: "resizes-content"` makes the soft keyboard shrink the
+ * viewport rather than slide over it, so `h-dvh` is the room actually left
+ * and the composer rides up without a line of JavaScript measuring anything.
+ */
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
+  interactiveWidget: "resizes-content",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/web/components/Chat.tsx
+++ b/web/components/Chat.tsx
@@ -278,14 +278,22 @@ export function Chat({
       {/* A column with a ceiling, so the composer is laid out first and the
           cards above it take whatever is left. Two vh caps that did not know
           about each other left the composer half off the bottom of a short
-          window — the thing this bar exists to keep reachable. */}
-      {/* `pb-4` because this is now the bottom of the window. The session used
-          to be a page inside a padded wrapper, which is where the composer's
-          breathing room came from; in the workbench it fills its pane, and
-          without this the composer — or the line of repositories under it —
-          sits flush against the edge of the screen. `px-4` matches the reading
-          column above so the two stay on one line. */}
-      <div className="relative mx-auto flex max-h-[85vh] w-full max-w-[860px] shrink-0 flex-col bg-ground px-4 pt-3 pb-4">
+          window — the thing this bar exists to keep reachable.
+
+          `dvh` rather than `vh`. With a soft keyboard up, `vh` is still the
+          window as it was *before* the keyboard — so 85vh of a 600px phone is
+          510px of a 280px space, the cap never engages, and the composer this
+          exists to keep reachable is under the keyboard. `dvh` is the room
+          actually left, which the viewport's `interactiveWidget` setting makes
+          shrink when the keyboard comes up. */}
+      {/* It pads for the home indicator because this is now the bottom of the
+          window, and `viewport-fit: cover` draws under it. The
+          session used to be a page inside a padded wrapper, which is where the
+          composer's breathing room came from; in the workbench it fills its
+          pane, and without this the composer — or the line of repositories
+          under it — sits flush against the edge of the screen. `px-4` matches
+          the reading column above so the two stay on one line. */}
+      <div className="relative mx-auto flex max-h-[85dvh] w-full max-w-[860px] shrink-0 flex-col bg-ground px-4 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
         {/* The transcript scrolls under this, so without a fade the last line
             is cut in half by the composer's top edge. */}
         <div

--- a/web/components/Composer.chat.tsx
+++ b/web/components/Composer.chat.tsx
@@ -6,7 +6,9 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { takeDraft } from "@/src/workspace/draft";
 import { useAttachFile, useListFiles } from "@/src/api/generated/sessions/sessions";
 import type { Attached, Checkout, SlashCommand, Usage } from "@/src/api/generated/model";
-import { Picker, type Control } from "@/components/Settings.chat";
+import type { Control } from "@/components/Settings.chat";
+import { Pickers } from "@/components/Pickers.chat";
+import { useHasRail } from "@/src/workspace/layout";
 import { Context } from "@/components/Context.chat";
 import type { Limits } from "@/src/api/conversation";
 
@@ -61,6 +63,9 @@ export function ChatComposer({
   // paint an empty composer and then fill it, which reads as the page changing
   // its mind. `takeDraft` removes what it returns, so a reload does not put the
   // issue back on top of whatever has since been typed.
+  /* Whether Enter is a send or a newline — see the key handler below. */
+  const sends = useHasRail();
+
   const [draft, setDraft] = useState(() => takeDraft(sessionId) ?? "");
   const [images, setImages] = useState<Attached[]>([]);
   const [over, setOver] = useState(false);
@@ -298,9 +303,14 @@ export function ChatComposer({
                 return;
               }
             }
-            // Enter sends. This is a message box, not an editor — a newline
-            // needs a modifier.
-            if (e.key === "Enter" && !e.shiftKey) {
+            // Enter sends, on a keyboard that has a Shift to hold for the
+            // newline. A soft keyboard does not: Return is where every
+            // messaging app on the device puts a line break, there is no
+            // modifier under a thumb, and a message box that sends half a
+            // sentence every time somebody starts a second paragraph is not a
+            // message box. Below `md` the arrow is the only way to send, which
+            // is why it is a 44px target.
+            if (e.key === "Enter" && !e.shiftKey && sends) {
               e.preventDefault();
               submit();
             }
@@ -310,6 +320,15 @@ export function ChatComposer({
             live ? "Ask for follow-up changes, or attach a file" : "This session has finished."
           }
           disabled={!live}
+          // What the Return key is called on a soft keyboard. Without this it
+          // says "return" while doing something else, or "send" while
+          // inserting a newline — both of which are the keyboard lying about
+          // the app.
+          enterKeyHint={sends ? "send" : "enter"}
+          // 14px here, and 16px below `md` — see the unlayered rule at the
+          // foot of `globals.css`, which every field in the app inherits.
+          // Under 16px iOS zooms the page when a field takes focus and does
+          // not zoom back out, and this is the field everybody touches.
           className="scroll-slim min-h-[52px] w-full resize-none bg-transparent px-4.5 pt-3.5 text-body text-text placeholder:text-mute focus:outline-none disabled:opacity-50"
         />
 
@@ -338,19 +357,11 @@ export function ChatComposer({
           />
 
           {/* One per knob this agent has, in the order the server gave
-              them. A session whose agent has none — or whose agent has not
-              said what its models are yet — shows nothing here rather than
+              them — collapsed to one chip and a sheet where there is not room
+              for three. A session whose agent has none — or whose agent has
+              not said what its models are yet — shows nothing here rather than
               a picker that cannot be right. */}
-          {controls.map((control) => (
-            <Picker
-              key={control.kind}
-              choices={control.choices}
-              current={control.current ?? undefined}
-              fallback={control.fallback}
-              disabled={!live}
-              onPick={(v) => onSet(control.kind, v)}
-            />
-          ))}
+          <Pickers controls={controls} disabled={!live} onSet={onSet} />
 
           <div className="ml-auto flex items-center gap-3">
             {usage && <Context usage={usage} limits={limits} />}

--- a/web/components/Modal.tsx
+++ b/web/components/Modal.tsx
@@ -5,17 +5,40 @@ import { LoaderCircle, X } from "lucide-react";
 import { Button, Icon } from "./ui";
 import type { PendingAuth } from "@/src/api/generated/model";
 import { ApiError } from "@/src/api/http";
+import { useDismissible } from "@/src/workspace/dismissible";
 
+/**
+ * A card on a desk, a sheet on a phone.
+ *
+ * The same component either way, because it is the same thing: one decision,
+ * asked once, over whatever you were doing. What changes below `md` is only
+ * that a 520px card floating in a 24px margin becomes the screen — which is
+ * what it nearly was already, and pretending otherwise cost the edges and left
+ * the confirm button somewhere you had to scroll to find.
+ *
+ * As a sheet it gets three things a card does not need: a floor that is above
+ * the home indicator, a header tall enough to have a real target in it, and
+ * Back as a way out.
+ */
 export function Modal({
   title,
   onClose,
   children,
   wide,
+  /**
+   * A floor pinned to the bottom of the sheet, rather than scrolling with it.
+   *
+   * For the one flow with a long body and a decision at the end of it — see
+   * `ShipSheet`. Above `md` this is drawn where it always was, at the end of
+   * the card.
+   */
+  floor,
 }: {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
   wide?: boolean;
+  floor?: React.ReactNode;
 }) {
   useEffect(() => {
     const k = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -23,25 +46,47 @@ export function Modal({
     return () => window.removeEventListener("keydown", k);
   }, [onClose]);
 
+  useDismissible(true, onClose, "modal");
+
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-6 sm:p-10">
+    <div className="fixed inset-0 z-50 flex justify-center overflow-hidden sm:items-start sm:overflow-y-auto sm:p-10">
       <div className="fixed inset-0 bg-ground/80 backdrop-blur-[3px]" onClick={onClose} />
       <div
-        className={`relative my-auto w-full rounded-lg border border-line bg-panel shadow-float ${
-          wide ? "max-w-[620px]" : "max-w-[520px]"
+        className={`relative flex h-full w-full flex-col overflow-hidden border-line bg-panel sm:my-auto sm:h-auto sm:max-h-full sm:rounded-lg sm:border sm:shadow-float ${
+          wide ? "sm:max-w-[620px]" : "sm:max-w-[520px]"
         }`}
       >
-        <div className="flex items-center gap-3 border-b border-line px-5 py-3">
+        <div className="shrink-0 border-b border-line pt-[env(safe-area-inset-top)]">
+        <div className="flex items-center gap-3 px-5 py-3">
           <span className="eyebrow">{title}</span>
           <button
             onClick={onClose}
-            className="-mr-1 ml-auto rounded-sm p-1 text-mute transition-colors hover:bg-raise hover:text-bone"
+            className="-mr-3 ml-auto grid h-11 w-11 place-items-center rounded-sm text-mute transition-colors hover:bg-raise hover:text-bone sm:-mr-1 sm:h-auto sm:w-auto sm:p-1"
             aria-label="Close"
           >
             <Icon of={X} size={14} />
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        </div>
+
+        {/* The body scrolls, not the page behind it. On a desk this is the
+            card's own height and the scroller never engages; on a phone it is
+            everything between the header and the floor. */}
+        {/* A floor of its own pads for the home indicator; without one, the
+            body is the bottom of the sheet and pads for it here. */}
+        <div
+          className={`min-h-0 flex-1 overflow-y-auto p-5 ${
+            floor ? "" : "pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-5"
+          }`}
+        >
+          {children}
+        </div>
+
+        {floor && (
+          <div className="shrink-0 border-t border-line bg-panel px-5 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-3">
+            {floor}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/components/Overview.tsx
+++ b/web/components/Overview.tsx
@@ -16,6 +16,7 @@
  * that takes the whole window, because it is the only thing that needs it.
  */
 
+import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Plus, Waypoints } from "lucide-react";
@@ -111,6 +112,7 @@ export function Overview() {
     return { groups, total: groups.reduce((n, [, places]) => n + places.length, 0) };
   }, [repos, repo, state]);
 
+
   /** Every workspace on screen, and the ticked ones among them. */
   const onScreen = useMemo(
     () => shown.groups.flatMap(([, places]) => places),
@@ -119,6 +121,29 @@ export function Overview() {
   // Intersected rather than trusted: a ticked workspace that ends somewhere
   // else disappears from the list, and its id must not stay in the count.
   const chosen = onScreen.filter((p) => picked.has(p.id));
+  /**
+   * The same fleet, flattened and sorted by whether it wants you.
+   *
+   * What a phone shows instead of the grouped table. On a desk the eye sweeps
+   * a whole screen at once and grouping by repository is the useful order —
+   * you are looking for a place. On a phone one screen is four rows, so the
+   * order has to answer the question somebody opened the app to ask, and that
+   * question is "what needs me". Grouping would bury the one waiting workspace
+   * under a repository heading three scrolls down.
+   *
+   * Waiting, then working, then everything else; within each, the one that has
+   * been going longest first, because that is the one most likely to be stuck.
+   */
+  const ranked = useMemo(() => {
+    const rank = { waiting: 0, working: 1, idle: 2 } as const;
+    return onScreen
+      .slice()
+      .sort(
+        (a, b) =>
+          rank[doing(a)] - rank[doing(b)] ||
+          Date.parse(a.runs[0].createdAt) - Date.parse(b.runs[0].createdAt),
+      );
+  }, [onScreen]);
 
   /** Changing what is on screen throws the ticks away. */
   const refilter = (change: () => void) => {
@@ -150,7 +175,7 @@ export function Overview() {
           : "Nothing here.";
 
   return (
-    <div className="px-8 pt-8 pb-24">
+    <div className="px-4 pt-6 pb-24 md:px-8 md:pt-8">
       <PageHead
         eyebrow="Workspaces"
         title={
@@ -212,7 +237,12 @@ export function Overview() {
                       ? `${repos.total} · ${waiting.length} waiting`
                       : repos.total}
                 </span>
+                {/* Not on a phone. Ending several workspaces at once is
+                    deliberate and destructive, and it belongs on a screen
+                    where you can see all of what you are about to end —
+                    which is the same reason the rows below have no ticks. */}
                 {onScreen.length > 0 && (
+                  <span className="hidden md:block">
                   <EndThese
                     label={label}
                     places={going}
@@ -231,6 +261,7 @@ export function Overview() {
                       setReport(result);
                     }}
                   />
+                  </span>
                 )}
               </div>
             }
@@ -274,6 +305,21 @@ export function Overview() {
             </div>
           ) : (
             <>
+              {/* One fleet, two drawings. Below `md` the table's four fixed
+                  columns do not fit — 92px of agent marks and an 84px badge
+                  out of 375px leaves nothing for the name — and the tick-boxes
+                  that end six workspaces at once are not something anybody
+                  should reach for on a train. So the phone gets the flat
+                  ranked list and none of the bulk controls. */}
+              <div className="md:hidden">
+                <List flush>
+                  {ranked.map((place) => (
+                    <Pocket key={place.id} place={place} />
+                  ))}
+                </List>
+              </div>
+
+              <div className="hidden md:block">
               <Columns>
                 {/* Ticks what is on screen, not the fleet: filter first, tick
                     all, end. Anything else is a button that ends work nobody
@@ -335,6 +381,7 @@ export function Overview() {
                   </div>
                 ))}
               </List>
+              </div>
             </>
           )}
         </Card>
@@ -433,6 +480,59 @@ function Place({
         </Badge>
       </div>
     </Row>
+  );
+}
+
+/**
+ * One workspace, on a screen with room for two lines and nothing else.
+ *
+ * The desk's `Place` is a row of four columns and a tick-box beside a link.
+ * None of that survives 375px, and the parts worth keeping are not the parts
+ * that shrink well: what it is called, whether it wants you, and how long it
+ * has been going.
+ *
+ * No tick-box. Ending several workspaces at once is a deliberate, destructive
+ * thing that belongs on a screen where you can see all of what you are ending.
+ */
+function Pocket({ place }: { place: Workspace }) {
+  const anyWaiting = place.runs.some(needsYou);
+  const state = doing(place);
+
+  return (
+    <Link
+      href={`/sessions/${place.id}`}
+      className="flex min-h-[64px] items-center gap-3 px-4 py-2.5 transition-colors active:bg-raise"
+    >
+      <Signal status={place.runs[0].status} size={6} />
+
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="min-w-0 truncate text-title text-bone">{place.name}</span>
+          {/* The one loud thing, and the reason this list is sorted the way it
+              is. Ember means an agent stopped and cannot go on without you. */}
+          {anyWaiting && <span className="h-2 w-2 shrink-0 rounded-full bg-ember" />}
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-meta text-mute">
+            {place.branch ?? "—"}
+          </span>
+          {place.runs.slice(0, 3).map((run) => (
+            <AgentMark key={run.id} agent={run.agent} size={11} className="shrink-0 text-mute" />
+          ))}
+          <span className="shrink-0 font-mono text-micro text-mute">
+            {elapsed(minutesSince(place.runs[0].createdAt))}
+          </span>
+        </span>
+      </span>
+
+      {/* The word, not a badge. A badge is a column in a table and there is no
+          table here; `waiting` beside an ember dot would say it twice. */}
+      {state !== "waiting" && (
+        <span className="shrink-0 font-narrow text-micro tracking-[0.14em] text-mute uppercase">
+          {state}
+        </span>
+      )}
+    </Link>
   );
 }
 

--- a/web/components/Pickers.chat.tsx
+++ b/web/components/Pickers.chat.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * Every knob this session has, in the room there is for them.
+ *
+ * On a desk that is one `Picker` per control, side by side on the composer's
+ * floor — three words, plenty of room, and each one readable without being
+ * opened.
+ *
+ * On a phone it is not. `Opus 5`, `acceptEdits` and `high` beside a `+` and a
+ * send button is four controls and a picture in 375px, and the first casualty
+ * is the send button. So below `md` they collapse to one chip showing the
+ * thing anybody actually wants to see — the model — which opens a sheet with
+ * all of them.
+ *
+ * Which one is the summary is deliberate rather than "the first". A session's
+ * model is the thing people check before sending an expensive message; its
+ * permission mode is a thing they set once. If an agent reports no model, the
+ * chip falls back to whatever it does report, so it never collapses to nothing
+ * and hides controls that exist.
+ */
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Icon } from "@/components/ui";
+import { Modal } from "@/components/Modal";
+import { Picker, type Control } from "@/components/Settings.chat";
+
+export function Pickers({
+  controls,
+  disabled,
+  onSet,
+}: {
+  controls: Control[];
+  disabled: boolean;
+  onSet: (kind: Control["kind"], value: string) => void;
+}) {
+  const [sheet, setSheet] = useState(false);
+
+  if (controls.length === 0) return null;
+
+  const summary = controls.find((c) => c.kind === "model") ?? controls[0];
+  const showing =
+    summary.choices.find((c) => c.value === summary.current)?.label ??
+    summary.current ??
+    summary.fallback;
+
+  return (
+    <>
+      {/* The desk's row. Hidden rather than not rendered, so there is one list
+          of controls and not two that can disagree about what a session has. */}
+      <span className="hidden items-center gap-0.5 md:flex">
+        {controls.map((control) => (
+          <Picker
+            key={control.kind}
+            choices={control.choices}
+            current={control.current ?? undefined}
+            fallback={control.fallback}
+            disabled={disabled}
+            onPick={(v) => onSet(control.kind, v)}
+          />
+        ))}
+      </span>
+
+      <button
+        onClick={() => setSheet(true)}
+        disabled={disabled}
+        aria-label="Settings for this session"
+        className="flex min-h-[44px] max-w-[14ch] items-center gap-1 rounded-full px-2.5 text-ui text-dim transition-colors hover:bg-raise hover:text-bone disabled:opacity-50 md:hidden"
+      >
+        <span className="truncate">{showing}</span>
+        <Icon of={ChevronDown} size={12} className="shrink-0 opacity-60" />
+      </button>
+
+      {sheet && (
+        <Modal title="This session" onClose={() => setSheet(false)}>
+          <div className="flex flex-col gap-4">
+            {controls.map((control) => (
+              <Knob
+                key={control.kind}
+                control={control}
+                disabled={disabled}
+                onPick={(v) => {
+                  onSet(control.kind, v);
+                  setSheet(false);
+                }}
+              />
+            ))}
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+/**
+ * One control, opened out.
+ *
+ * A list rather than a dropdown inside a sheet. A menu that opens another menu
+ * on a phone is two layers to dismiss and a target that moves under the thumb
+ * between them; there is room here to just show the choices.
+ */
+function Knob({
+  control,
+  disabled,
+  onPick,
+}: {
+  control: Control;
+  disabled: boolean;
+  onPick: (value: string) => void;
+}) {
+  return (
+    <div>
+      <p className="eyebrow mb-1.5">{control.fallback}</p>
+      <div className="flex flex-col">
+        {control.choices.map((choice, i) => {
+          const on = matches(choice.value, control.current ?? undefined);
+          const first = choice.grave && !control.choices[i - 1]?.grave;
+          return (
+            <button
+              key={choice.value}
+              disabled={disabled}
+              onClick={() => !on && onPick(choice.value)}
+              className={`flex min-h-[52px] items-center gap-3 rounded-md px-2 text-left transition-colors enabled:hover:bg-raise disabled:opacity-50 ${
+                first ? "mt-1 border-t border-line pt-1" : ""
+              }`}
+            >
+              <span className="min-w-0 flex-1">
+                <span
+                  className={`block text-ui ${
+                    on ? "text-bone" : choice.grave ? "text-dim" : "text-text"
+                  }`}
+                >
+                  {choice.label}
+                </span>
+                {choice.note && (
+                  <span className="block text-meta text-mute">{choice.note}</span>
+                )}
+              </span>
+              {/* The one in force, said with a mark rather than only with a
+                  brighter label — on a phone in daylight, one step of grey is
+                  not a signal. */}
+              {on && <span className="shrink-0 text-ui text-bone">✓</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Whether a choice is the thing currently in force.
+ *
+ * The same loose match `Picker` makes, and for the same reason: the agent
+ * reports `claude-opus-5[1m]` where the command takes `opus[1m]`.
+ */
+function matches(value: string, current?: string): boolean {
+  if (!current) return false;
+  return current === value || current.includes(value);
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -4,15 +4,27 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMe, useLogout } from "@/src/api/generated/auth/auth";
 import { forgetToken } from "@/src/api/http";
-import { useState } from "react";
-import { BookOpen, CircleDashed, LayoutList, ListTodo, Plus, Settings2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  BookOpen,
+  CircleDashed,
+  LayoutList,
+  ListTodo,
+  Menu,
+  Plus,
+  Settings2,
+  X,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Mark, Signal } from "./Signal";
+import { useHasRail } from "@/src/workspace/layout";
+import { useDrawer } from "@/src/workspace/drawer";
 import { NewWorkspaceModal } from "./NewWorkspace";
 import { AgentMark } from "./AgentMark";
 import { Button, GithubMark, Icon } from "./ui";
 import { useListSessions } from "@/src/api/generated/sessions/sessions";
 import { doing, group, shortRepo, type Workspace } from "@/src/api/workspaces";
+import { useDismissible } from "@/src/workspace/dismissible";
 import { elapsed, minutesSince, needsYou, unfinished } from "@/src/api/view";
 
 /**
@@ -31,6 +43,21 @@ const NAV: { href: string; label: string; icon: LucideIcon }[] = [
 
 export function Shell({ children }: { children: React.ReactNode }) {
   const path = usePathname();
+  /* Open only below `md`, where the rail is not on screen to begin with. */
+  const { open: drawer, show: openDrawer, hide: closeDrawer } = useDrawer();
+  const hasRail = useHasRail();
+
+  /* Arriving somewhere is the end of navigating to it. Without this, tapping a
+     workspace left the drawer sitting over the workspace it had just opened,
+     and the only way out was the backdrop — which reads as the tap not having
+     worked. */
+  useEffect(() => closeDrawer(), [path, closeDrawer]);
+
+  /* Back closes it rather than leaving the page.
+     The drawer is a layer over the screen, and on Android the button that
+     dismisses a layer is the system one. Every layer in the app does this the
+     same way — see `useDismissible`. */
+  useDismissible(drawer, closeDrawer, "drawer");
 
   /* Onboarding and signing in run full-bleed — no fleet to navigate yet. */
   if (path.startsWith("/setup") || path.startsWith("/login")) return <>{children}</>;
@@ -44,11 +71,23 @@ export function Shell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-dvh overflow-hidden">
-      {/* Fixed to the window, whatever is in it. The list of running sessions
+      {/* Below `md` the rail is a drawer over the page; at `md` and above it is
+          the column it has always been. One element either way — a second
+          component would be the same list of workspaces written twice, drifting
+          apart the first time either was touched.
+
+          Fixed to the window, whatever is in it. The list of running sessions
           grows without bound, and a rail that grows with it pushes the page
           past the viewport and scrolls everything — including the session
           somebody is reading. */}
-      <aside className="hidden h-full w-[236px] shrink-0 flex-col overflow-hidden border-r border-line bg-panel md:flex">
+      <aside
+        // Hidden from the reading order when it is off-screen, or the whole
+        // fleet sits in the tab order of a page that is not showing it.
+        inert={!hasRail && !drawer ? true : undefined}
+        className={`fixed inset-y-0 left-0 z-50 flex h-full w-[300px] shrink-0 flex-col overflow-hidden border-r border-line bg-panel transition-transform duration-200 ease-swift md:static md:z-auto md:w-[236px] md:translate-x-0 md:transition-none ${
+          drawer ? "translate-x-0 shadow-float" : "-translate-x-full"
+        }`}
+      >
         <div className="flex items-center gap-2.5 px-4 pt-4 pb-5">
           <span className="text-bone">
             <Mark size={20} />
@@ -56,6 +95,16 @@ export function Shell({ children }: { children: React.ReactNode }) {
           <span className="font-narrow text-ui font-semibold tracking-[0.22em] text-bone uppercase">
             Firetower
           </span>
+          {/* A way out that is not the backdrop. The backdrop works and is not
+              discoverable, and on a wide phone the drawer's own edge is a long
+              reach from the thumb that opened it. */}
+          <button
+            onClick={closeDrawer}
+            aria-label="Close the menu"
+            className="-mr-1.5 ml-auto grid h-11 w-11 place-items-center rounded-md text-mute transition-colors hover:bg-raise hover:text-bone md:hidden"
+          >
+            <Icon of={X} size={16} />
+          </button>
         </div>
 
         <nav className="flex flex-col gap-0.5 px-2">
@@ -95,16 +144,68 @@ export function Shell({ children }: { children: React.ReactNode }) {
         <WhoAmI />
       </aside>
 
-      {/* The workbench owns its own scrolling — tabs, a transcript that follows
-          itself, a terminal. Every other page is a document and scrolls here. */}
-      <main
-        className={`min-w-0 flex-1 ${workbench ? "flex overflow-hidden" : "overflow-y-auto"}`}
-      >
-        {children}
-      </main>
+      {/* What the drawer is over. Only below `md`, and only while it is open —
+          at `md` the rail is part of the layout and there is nothing to dim. */}
+      {drawer && (
+        <button
+          onClick={closeDrawer}
+          aria-label="Close the menu"
+          tabIndex={-1}
+          className="fixed inset-0 z-40 bg-ground/70 backdrop-blur-[2px] md:hidden"
+        />
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        {/* The way to the drawer, on the screens that have nowhere else to put
+            it. Not on the workbench: a workspace draws its own header, with the
+            same `☰` in the same place and a `‹` beside it, and two stacked bars
+            saying the same thing is 100px of a phone spent on furniture. */}
+        {!workbench && (
+          <header className="shrink-0 border-b border-line bg-panel pt-[env(safe-area-inset-top)] md:hidden">
+            {/* The inset pads the wrapper; the row keeps its own height. See
+                the same shape in `Pushed` and `WorkspaceHeader`. */}
+            <div className="flex h-14 items-center gap-1 px-2">
+              <button
+                onClick={openDrawer}
+                aria-label="Open the menu"
+                className="grid h-11 w-11 shrink-0 place-items-center rounded-md text-dim transition-colors hover:bg-raise hover:text-bone"
+              >
+                <Icon of={Menu} size={16} />
+              </button>
+              <span className="font-narrow text-ui font-semibold tracking-[0.22em] text-bone uppercase">
+                {TITLE[path] ?? "Firetower"}
+              </span>
+            </div>
+          </header>
+        )}
+
+        {/* The workbench owns its own scrolling — tabs, a transcript that
+            follows itself, a terminal. Every other page is a document and
+            scrolls here. */}
+        <main
+          className={`min-w-0 flex-1 ${workbench ? "flex overflow-hidden" : "overflow-y-auto"}`}
+        >
+          {children}
+        </main>
+      </div>
     </div>
   );
 }
+
+/**
+ * What the phone's bar is called, per page.
+ *
+ * Only the destinations the drawer offers. Anything else falls back to the
+ * product name, which is honest for a page reached from a link — better than
+ * deriving a title from the path and printing "Repos" in the middle of a
+ * settings screen that calls itself Configuration.
+ */
+const TITLE: Record<string, string> = {
+  "/": "Dashboard",
+  "/tasks": "Tasks",
+  "/configuration": "Configuration",
+  "/sessions": "Sessions",
+};
 
 /**
  * One destination.

--- a/web/components/Tasks.tsx
+++ b/web/components/Tasks.tsx
@@ -83,7 +83,7 @@ export function Tasks() {
   };
 
   return (
-    <div className="px-8 pt-6 pb-24">
+    <div className="px-4 pt-5 pb-24 md:px-8 md:pt-6">
       <PageHead eyebrow="Tasks" title={isPending ? "Looking…" : `${data?.total ?? tasks.length} to pick from.`}>
         Read from GitHub as you look. Starting one opens a workspace.
       </PageHead>

--- a/web/components/Tasks.tsx
+++ b/web/components/Tasks.tsx
@@ -41,12 +41,22 @@ import {
 import { elapsed, minutesSince } from "@/src/api/view";
 
 /** One set of widths, shared by the legend and every row under it. */
+/**
+ * The columns, and which of them a phone has room for.
+ *
+ * These add up to 464px of fixed width, which is wider than a phone. The title
+ * beside them is `flex-1 min-w-0`, and what `min-w-0` means when the row
+ * overflows is *zero*: the one thing somebody reads a task list for collapsed
+ * to nothing, and the buttons at the end of the row sat off the side of the
+ * screen. So everything that is context rather than the task itself is dropped
+ * below `md`, and the title gets the room back.
+ */
 const COL = {
   id: "w-[72px] shrink-0",
-  who: "w-[88px] shrink-0",
-  state: "w-[76px] shrink-0",
-  when: "w-[76px] shrink-0",
-  act: "w-[152px] shrink-0",
+  who: "hidden md:flex w-[88px] shrink-0",
+  state: "hidden md:block w-[76px] shrink-0",
+  when: "hidden md:block w-[76px] shrink-0",
+  act: "shrink-0 md:w-[152px]",
 };
 
 export function Tasks() {
@@ -313,7 +323,7 @@ function TaskRow({
         </div>
       </div>
 
-      <div className={`${COL.who} flex -space-x-1.5`}>
+      <div className={`${COL.who} -space-x-1.5`}>
         {task.assignees.slice(0, 3).map((who) => (
           <Avatar key={who.login} name={who.login} />
         ))}
@@ -333,12 +343,16 @@ function TaskRow({
           one and is the last thing on the row. Both are named, because an icon
           alone is a guess on first sight. */}
       <div className={`${COL.act} flex items-center justify-end gap-2`}>
+        {/* Revealed on hover on a desk, where a row full of buttons is noise
+            until you are pointing at it. A phone has no hover, so there it is
+            simply there — it used to sit at `opacity-0` for ever, which is a
+            control you can tap only by knowing where it is. */}
         <Button
           variant="quiet"
           size="sm"
           onClick={onRead}
           title="Read it"
-          className="opacity-0 transition-opacity group-hover:opacity-100"
+          className="md:opacity-0 md:transition-opacity md:group-hover:opacity-100"
         >
           View
         </Button>

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -20,9 +20,17 @@ const VARIANT: Record<Variant, string> = {
     "text-brick border border-brick-deep hover:bg-brick-tint disabled:text-mute disabled:border-line",
 };
 
+/**
+ * Two heights, and a floor under both on a touch screen.
+ *
+ * 32px is right for a pointer, which lands where it is aimed, and wrong for a
+ * thumb, which does not. `max-md:min-h-[44px]` costs nothing at a desk — the
+ * button is already taller than the minimum — and makes every button in the
+ * app a real target below `md` without a second variant to remember to use.
+ */
 const SIZE = {
-  sm: "h-7 gap-1.5 px-2.5 text-meta rounded-sm",
-  md: "h-8 gap-2 px-3 text-ui rounded-md",
+  sm: "h-7 gap-1.5 px-2.5 text-meta rounded-sm max-md:min-h-[44px]",
+  md: "h-8 gap-2 px-3 text-ui rounded-md max-md:min-h-[44px]",
 } as const;
 
 export function Button({

--- a/web/components/ui/IconButton.tsx
+++ b/web/components/ui/IconButton.tsx
@@ -16,7 +16,11 @@ const VARIANT: Record<Variant, string> = {
   outline: "border border-line text-dim hover:border-mute/60 hover:text-bone",
 };
 
-const SIZE = { sm: "h-8 w-8", md: "h-10 w-10" } as const;
+/** The same floor `Button` takes: a thumb does not land where it is aimed. */
+const SIZE = {
+  sm: "h-8 w-8 max-md:h-11 max-md:w-11",
+  md: "h-10 w-10 max-md:h-11 max-md:w-11",
+} as const;
 
 export function IconButton({
   of,

--- a/web/components/ui/Panel.tsx
+++ b/web/components/ui/Panel.tsx
@@ -26,7 +26,9 @@ export function PageHead({
   aside?: React.ReactNode;
 }) {
   return (
-    <header className="mb-5 flex items-start gap-4">
+    // Stacked below `sm`, because a heading and a button side by side at
+    // 375px is a heading wrapped to four lines beside a button.
+    <header className="mb-5 flex flex-col items-start gap-3 sm:flex-row sm:items-start sm:gap-4">
       <div className="min-w-0 flex-1">
         <div className="eyebrow">{eyebrow}</div>
         <h1 className="mt-1.5 text-display font-semibold text-bone">{title}</h1>

--- a/web/components/workspace/CloseWorkspace.tsx
+++ b/web/components/workspace/CloseWorkspace.tsx
@@ -105,6 +105,18 @@ export function CloseWorkspace({
 
       {asking && (
         <Modal title="Close this workspace?" onClose={() => setAsking(false)}>
+          {/* Which one, before what happens to it.
+              The branch was printed only in the case where nothing was at risk
+              — "`{branch}` is pushed, so the commits are safe" — so the one
+              time it mattered most, the sheet did not say which workspace it
+              was about to destroy. On a desk you can see the rail behind the
+              modal and answer that yourself; below `xl` there is no rail, and
+              this arrives from a menu two taps after the last time anything
+              named the place. */}
+          <p className="mb-3 min-w-0 truncate font-mono text-meta text-dim">
+            ⑂ {session.branch ?? "no branch"}
+          </p>
+
           <p className="text-ui leading-[1.6] text-dim">
             {founding
               ? others > 0
@@ -128,7 +140,7 @@ export function CloseWorkspace({
           ) : (
             <p className="mt-3 text-meta leading-[1.55] text-mute">
               {pushed
-                ? `${session.branch} is pushed, so the commits are safe on the remote.`
+                ? "It is pushed, so the commits are safe on the remote."
                 : "Nothing here is waiting to be saved."}
             </p>
           )}

--- a/web/components/workspace/DiffTab.tsx
+++ b/web/components/workspace/DiffTab.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { useSessionDiff } from "@/src/api/generated/sessions/sessions";
 import { ApiError } from "@/src/api/http";
 import { useOpen, useTabs } from "@/src/workspace/tabs";
+import { useCodeSize } from "@/src/workspace/code";
 
 /**
  * What changed in one file.
@@ -10,68 +12,276 @@ import { useOpen, useTabs } from "@/src/workspace/tabs";
  * One file rather than the whole list, because the list already exists in the
  * panel on the right — and a tab that reproduced it would mean two places to
  * choose a file and a selection that disagreed between them.
+ *
+ * ## A patch is 80 columns and a phone is about 40
+ *
+ * So it wraps, and a wrapped line says so. This is the single largest
+ * difference between a diff that can be read on a phone and one that cannot:
+ * unwrapped, every line of every hunk is a horizontal scroll, and the `+` and
+ * `−` that say what happened are the part that scrolls off.
+ *
+ * Saying so is a hanging indent rather than a glyph in the margin. A glyph
+ * would have to be placed at the point the line broke, and only the browser
+ * knows where that is — putting one there means measuring the text ourselves
+ * at three font sizes and every window width, to draw an arrow. The indent
+ * needs none of that and answers the same question, which is the one a diff
+ * must never get wrong: a continuation is inset past the marker column, so it
+ * cannot be misread as a context line following an added one.
+ *
+ * Wrapping is the default and not the law — `⤢` turns it off for anybody who
+ * wants the horizontal scroll back, on a wide screen or out of habit.
  */
-export function DiffTab({ sessionId, path }: { sessionId: string; path: string }) {
+export function DiffTab({
+  sessionId,
+  path,
+  /** Pushed over a workspace, which draws the path and the way back itself. */
+  bare,
+}: {
+  sessionId: string;
+  path: string;
+  bare?: boolean;
+}) {
   const { data: files = [], isLoading, error } = useSessionDiff(sessionId, undefined, {
     query: { refetchInterval: 8_000 },
   });
   const { set } = useTabs();
   const open = useOpen();
+  const { size, cycle } = useCodeSize();
+  const [wrap, setWrap] = useState(true);
 
   const file = files.find((f) => f.path === path);
+
+  /* Which of the changed files this is, so there is somewhere to go next.
+     Only meaningful when it was opened from the list — which, below `xl`, is
+     the only way to open one. */
+  const at = files.findIndex((f) => f.path === path);
+  const move = (by: number) => {
+    const next = files[at + by];
+    if (next) open.diff(next.path);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="flex h-9 shrink-0 items-center gap-2 border-b border-line bg-panel px-3">
-        <span className="min-w-0 flex-1 truncate font-mono text-meta text-slate" title={path}>
-          {path}
-        </span>
+        {!bare && (
+          <span className="min-w-0 flex-1 truncate font-mono text-meta text-slate" title={path}>
+            {path}
+          </span>
+        )}
         {file && (
           <>
             <span className="shrink-0 font-mono text-micro text-sage">+{file.added}</span>
             <span className="shrink-0 font-mono text-micro text-brick">−{file.removed}</span>
           </>
         )}
-        <button
-          onClick={() => open.file(path)}
-          title="Open the file itself"
-          className="shrink-0 text-meta text-mute transition-colors hover:text-bone"
+
+        {bare && <span className="flex-1" />}
+
+        {/* What pinch-to-zoom was doing before it was taken away.
+            Better than pinch, which is why the trade is defensible: this
+            re-wraps the patch to the new size instead of making a wide thing
+            wider and pushing half of it off the screen. */}
+        <Control
+          label={`Code size — ${size}px`}
+          onClick={cycle}
+          className="font-narrow font-semibold"
         >
+          A<span className="text-micro">a</span>
+        </Control>
+
+        <Control label={wrap ? "Stop wrapping long lines" : "Wrap long lines"} onClick={() => setWrap(!wrap)}>
+          {wrap ? "⤢" : "⤡"}
+        </Control>
+
+        <Control label="Open the file itself" onClick={() => open.file(path)}>
           ▤
-        </button>
-        {!set?.split && (
-          <button
-            onClick={() => open.diff(path, true)}
-            title="Open beside"
-            className="shrink-0 text-meta text-mute transition-colors hover:text-bone"
-          >
+        </Control>
+
+        {!bare && !set?.split && (
+          <Control label="Open beside" onClick={() => open.diff(path, true)}>
             ⊞
-          </button>
+          </Control>
         )}
       </header>
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        {isLoading && <Note>Reading the workspace…</Note>}
-        {error && (
-          <Note>{error instanceof ApiError ? error.message : "Couldn't read the changes."}</Note>
-        )}
-        {!isLoading && !error && !file && (
-          <Note>
-            Nothing has changed in that file — it may have been committed, or reverted, since this
-            tab was opened.
-          </Note>
-        )}
-        {file && (
-          <pre className="px-3 py-2 font-mono text-meta leading-[1.6]">
-            {file.patch.split("\n").map((line, i) => (
-              <div key={i} className={colour(line)}>
-                {line || " "}
-              </div>
-            ))}
-          </pre>
-        )}
+      <Patch
+        patch={file?.patch}
+        wrap={wrap}
+        size={size}
+        empty={
+          isLoading
+            ? "Reading the workspace…"
+            : error
+              ? error instanceof ApiError
+                ? error.message
+                : "Couldn't read the changes."
+              : !file
+                ? "Nothing has changed in that file — it may have been committed, or reverted, since this was opened."
+                : undefined
+        }
+        onPrev={at > 0 ? () => move(-1) : undefined}
+        onNext={at >= 0 && at < files.length - 1 ? () => move(1) : undefined}
+      />
+
+      {/* Where you are in the change, and the way through it.
+          The swipe has a visible twin, always: a gesture nothing on screen
+          admits to is a gesture only the person who built it knows about. */}
+      {bare && files.length > 1 && at >= 0 && (
+        <div className="flex shrink-0 items-center border-t border-line bg-panel pb-[env(safe-area-inset-bottom)]">
+          <Step onClick={at > 0 ? () => move(-1) : undefined}>‹ Prev</Step>
+          <span className="flex-1 text-center font-mono text-micro text-mute">
+            {at + 1} of {files.length}
+          </span>
+          <Step onClick={at < files.length - 1 ? () => move(1) : undefined}>Next ›</Step>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The patch itself.
+ *
+ * Split into a component of its own so the swipe listener has an element to
+ * hang off that is exactly the region somebody would swipe across.
+ */
+function Patch({
+  patch,
+  wrap,
+  size,
+  empty,
+  onPrev,
+  onNext,
+}: {
+  patch?: string;
+  wrap: boolean;
+  size: number;
+  empty?: string;
+  onPrev?: () => void;
+  onNext?: () => void;
+}) {
+  const box = useRef<HTMLDivElement>(null);
+  useSwipe(box, onPrev, onNext);
+
+  if (empty) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <p className="max-w-[44ch] text-center text-ui text-mute">{empty}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={box} className="min-h-0 flex-1 overflow-auto">
+      <div
+        className="px-3 py-2 font-mono leading-[1.6]"
+        // The one place a size is not from the scale, because it is a control
+        // rather than a decision: the reader picked it, out of the three in
+        // `CYCLE`, and the scale has nothing to say about that.
+        style={{ fontSize: `${size}px` }}
+      >
+        {(patch ?? "").split("\n").map((line, i) => (
+          <div
+            key={i}
+            className={`${colour(line)} ${
+              wrap
+                ? // Wrapped lines hang under the first character *after* the
+                  // marker column, so the `+`/`−` gutter stays one column wide
+                  // all the way down and a continuation cannot be read as a
+                  // line of its own.
+                  "pl-[2ch] -indent-[2ch] break-words whitespace-pre-wrap"
+                : "whitespace-pre"
+            }`}
+          >
+            {line || " "}
+          </div>
+        ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Left and right, across the changed files.
+ *
+ * Touch rather than pointer events: a pointer listener on a scroller competes
+ * with the scroll itself, and the browser has already decided this gesture is
+ * horizontal by the time `touchend` arrives.
+ *
+ * Only a clearly horizontal, clearly deliberate movement counts — 60px across
+ * and less than half that down. A diff is a tall thing people scroll, and a
+ * thumb that drifts sideways on the way down must not turn the page.
+ */
+function useSwipe(
+  on: React.RefObject<HTMLElement | null>,
+  onPrev?: () => void,
+  onNext?: () => void,
+) {
+  useEffect(() => {
+    const el = on.current;
+    if (!el) return;
+
+    let from: { x: number; y: number } | null = null;
+
+    const begin = (e: TouchEvent) => {
+      // One finger. Two is a scroll or a gesture and neither means "next".
+      from = e.touches.length === 1 ? { x: e.touches[0].clientX, y: e.touches[0].clientY } : null;
+    };
+
+    const end = (e: TouchEvent) => {
+      const start = from;
+      from = null;
+      if (!start || e.changedTouches.length !== 1) return;
+      const dx = e.changedTouches[0].clientX - start.x;
+      const dy = e.changedTouches[0].clientY - start.y;
+      if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx) / 2) return;
+      // Left drags the next file in from the right, which is the direction
+      // every paged interface on the device already means by it.
+      if (dx < 0) onNext?.();
+      else onPrev?.();
+    };
+
+    el.addEventListener("touchstart", begin, { passive: true });
+    el.addEventListener("touchend", end, { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", begin);
+      el.removeEventListener("touchend", end);
+    };
+  }, [on, onPrev, onNext]);
+}
+
+function Control({
+  label,
+  onClick,
+  children,
+  className = "",
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className={`grid h-8 min-w-8 shrink-0 place-items-center rounded-sm text-meta text-mute transition-colors hover:bg-raise hover:text-bone ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Step({ onClick, children }: { onClick?: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={!onClick}
+      className="min-h-[44px] px-4 text-ui text-dim transition-colors enabled:hover:text-bone disabled:text-mute/50"
+    >
+      {children}
+    </button>
   );
 }
 
@@ -83,12 +293,4 @@ function colour(line: string) {
   if (line.startsWith("@@")) return "text-slate";
   if (line.startsWith("diff --git") || line.startsWith("index ")) return "text-mute";
   return "text-dim";
-}
-
-function Note({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex h-full items-center justify-center px-8">
-      <p className="max-w-[44ch] text-center text-ui text-mute">{children}</p>
-    </div>
-  );
 }

--- a/web/components/workspace/Inspector.tsx
+++ b/web/components/workspace/Inspector.tsx
@@ -9,16 +9,13 @@ import {
   useSessionDiff,
   useSessionWork,
 } from "@/src/api/generated/sessions/sessions";
-import { useOpen } from "@/src/workspace/tabs";
 import { usePanel, VIEWS, type View } from "@/src/workspace/panel";
 import { Signal } from "@/components/Signal";
 import { STATUS_LABEL } from "@/src/api/view";
 import { shipping } from "@/src/api/ship";
 import { useListEvents } from "@/src/api/generated/events/events";
 import { stepLines, ready } from "@/components/Steps";
-import { PathRow, Counts } from "./PathRow";
-import { Tree } from "./Tree";
-import { ShipPanel } from "./ShipPanel";
+import { WorkspaceView } from "./Views";
 import { CloseWorkspace } from "./CloseWorkspace";
 
 /**
@@ -71,11 +68,12 @@ export function Inspector({ sessionId }: { sessionId: string | null }) {
           </div>
         ) : (
           <>
-            {panel.view === "files" && (
-              <Tree sessionId={sessionId} changed={new Set(files.map((f) => f.path))} />
-            )}
-            {panel.view === "changes" && <Changes sessionId={sessionId} />}
-            {panel.view === "ship" && <ShipPanel sessionId={sessionId} />}
+            <WorkspaceView
+              view={panel.view}
+              sessionId={sessionId}
+              changed={new Set(files.map((f) => f.path))}
+              onShip={() => panel.reveal("ship")}
+            />
             <Doing sessionId={sessionId} />
           </>
         )}
@@ -236,7 +234,7 @@ function Grip() {
  * is a set of views, and one of them silently being a destructive action is a
  * thing you only mispress once.
  */
-function Doing({ sessionId }: { sessionId: string }) {
+export function Doing({ sessionId }: { sessionId: string }) {
   const { data: session } = useGetSession(sessionId);
   // The same query the session tab runs, served from one cache entry — and kept
   // current by the socket rather than by either of them polling.
@@ -297,57 +295,3 @@ const LABEL: Record<string, string> = {
   Launch: "Starting the agent",
 };
 
-/** What is in the workspace that is not safely elsewhere. */
-function Changes({ sessionId }: { sessionId: string }) {
-  const { data: files = [], isLoading } = useSessionDiff(sessionId, undefined, {
-    query: { refetchInterval: 8_000 },
-  });
-  const open = useOpen();
-  const panel = usePanel();
-
-  const added = files.reduce((n, f) => n + f.added, 0);
-  const removed = files.reduce((n, f) => n + f.removed, 0);
-
-  return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center gap-2 border-b border-line px-3 py-1.5">
-        <span className="eyebrow">Changes</span>
-        <span className="ml-auto font-mono text-micro text-mute">
-          {isLoading ? "…" : files.length === 0 ? "none" : `${files.length} files`}
-        </span>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto px-1.5 py-1">
-        {files.map((f) => (
-          <PathRow
-            key={f.path}
-            path={f.path}
-            onClick={() => open.diff(f.path)}
-            trail={<Counts added={f.added} removed={f.removed} />}
-          />
-        ))}
-
-        {!isLoading && files.length === 0 && <Line>Nothing has changed yet.</Line>}
-      </div>
-
-      {files.length > 0 && (
-        <div className="shrink-0 border-t border-line px-3 py-2">
-          <p className="mb-2 font-mono text-micro text-mute">
-            <span className="text-sage">+{added}</span>{" "}
-            <span className="text-brick">−{removed}</span>
-          </p>
-          <button
-            onClick={() => panel.reveal("ship")}
-            className="w-full rounded-md border border-line py-1.5 text-meta text-dim transition-colors hover:border-line hover:text-bone"
-          >
-            Review &amp; ship →
-          </button>
-        </div>
-      )}
-    </section>
-  );
-}
-
-function Line({ children }: { children: React.ReactNode }) {
-  return <p className="px-1.5 py-1 text-meta text-mute">{children}</p>;
-}

--- a/web/components/workspace/OneColumn.tsx
+++ b/web/components/workspace/OneColumn.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * A workspace with one column: a header, a switcher, and one of four things.
+ *
+ * This is what the workbench is below `xl` — a phone, and every iPad but the
+ * 13" in landscape. Not a reduced version of the desk layout: the desk shows a
+ * rail, two panes and a panel at once because it has 1280px to do it in, and
+ * the honest answer at 400px or at 1000px is one surface at a time with a way
+ * to change which.
+ *
+ * The conversation stays mounted while you are in Diff or Ship. It holds an
+ * event stream and a socket, and tearing those down to look at a file list —
+ * then rebuilding them and repainting the transcript on the way back — is the
+ * difference between a switcher and navigation. It is the same rule the desk's
+ * `Pane` follows for its tabs, for the same reason.
+ */
+
+import { useEffect, useRef } from "react";
+import { useSessionDiff } from "@/src/api/generated/sessions/sessions";
+import { useScreen } from "@/src/workspace/screen";
+import { useOverlay } from "@/src/workspace/overlay";
+import { useNoZoom } from "@/src/workspace/touch";
+import { WorkspaceHeader } from "./WorkspaceHeader";
+import { WorkspaceView } from "./Views";
+import { SessionTab } from "./SessionTab";
+import { Pushed } from "./Pushed";
+
+export function OneColumn({
+  sessionId,
+  onBack,
+}: {
+  sessionId: string;
+  onBack: () => void;
+}) {
+  const { screen, show } = useScreen();
+  const { overlay, close } = useOverlay();
+  const surface = useRef<HTMLDivElement>(null);
+
+  // Pinch is a fumbled scroll in here. The CSS half is `.no-zoom`; this is the
+  // half Safari needs. See `touch.ts` — neither works alone.
+  useNoZoom(surface);
+
+  // Asked once and read twice: the count on `Diff`, and the marks in the tree.
+  // React Query serves both from one cache entry.
+  const { data: files = [] } = useSessionDiff(sessionId, undefined, {
+    query: { refetchInterval: 8_000 },
+  });
+
+  // A document belongs to the workspace it was opened from. Moving to another
+  // one and finding somebody else's diff still on top would be the app losing
+  // track of where it is.
+  useEffect(() => close(), [sessionId, close]);
+
+  return (
+    <div ref={surface} className="no-zoom relative flex min-w-0 flex-1 flex-col overflow-hidden">
+      <WorkspaceHeader sessionId={sessionId} changed={files.length} onBack={onBack} />
+
+      <div className="relative min-h-0 flex-1">
+        {/* Mounted always, hidden when it is not the one in front. */}
+        <div className={`absolute inset-0 ${screen === "chat" ? "" : "hidden"}`}>
+          <SessionTab sessionId={sessionId} />
+        </div>
+
+        {screen !== "chat" && (
+          <div className="absolute inset-0 flex flex-col overflow-hidden bg-panel">
+            <WorkspaceView
+              view={screen}
+              sessionId={sessionId}
+              changed={new Set(files.map((f) => f.path))}
+              onShip={() => show("ship")}
+            />
+          </div>
+        )}
+
+        {overlay && <Pushed sessionId={sessionId} overlay={overlay} />}
+      </div>
+    </div>
+  );
+}

--- a/web/components/workspace/PathRow.tsx
+++ b/web/components/workspace/PathRow.tsx
@@ -37,7 +37,11 @@ export function PathRow({
 
   return (
     <div
-      className={`group flex items-center gap-2 rounded-sm px-1.5 py-1 transition-colors ${
+      // 25px is a fine row for a pointer and not a target for a thumb. Below
+      // `xl` these three lists *are* the screen — the tree, the changes and
+      // what is going into the commit — rather than a 320px panel beside it,
+      // so the row grows to 44 and the density goes.
+      className={`group flex items-center gap-2 rounded-sm px-1.5 py-1 transition-colors max-xl:min-h-[44px] ${
         on ? "bg-raise" : "hover:bg-raise/60"
       }`}
     >
@@ -102,7 +106,7 @@ export function Fold({
     <section className="min-h-0">
       <button
         onClick={onToggle}
-        className="flex w-full items-center gap-1.5 px-1.5 py-1.5 text-left"
+        className="flex w-full items-center gap-1.5 px-1.5 py-1.5 text-left max-xl:min-h-[44px]"
       >
         <span
           className="shrink-0 text-micro text-mute transition-transform"

--- a/web/components/workspace/Pushed.tsx
+++ b/web/components/workspace/Pushed.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * A file, a diff or a preview, over the workspace it came from.
+ *
+ * The desk opens these beside the conversation. One column cannot, so they are
+ * pushed on top with a `‹` that goes back to the list they were opened from —
+ * which is the list that is still mounted underneath, on the screen it was
+ * left on. Nothing is lost and nothing needs remembering.
+ *
+ * See `overlay.ts` for why this is not a tab.
+ */
+
+import { useEffect } from "react";
+import { ChevronLeft } from "lucide-react";
+import { Icon } from "@/components/ui";
+import { FileTab } from "./FileTab";
+import { DiffTab } from "./DiffTab";
+import { PreviewTab } from "./PreviewTab";
+import { leafOf } from "@/src/api/text";
+import { useOverlay, type Overlay } from "@/src/workspace/overlay";
+import { useDismissible } from "@/src/workspace/dismissible";
+
+export function Pushed({ sessionId, overlay }: { sessionId: string; overlay: Overlay }) {
+  const { close } = useOverlay();
+
+  // Back closes the document rather than leaving the workspace, which is what
+  // it means on every phone anybody has ever used.
+  useDismissible(true, close, "pushed");
+
+  // Escape too, for the tablet band — this is not only a phone component, and
+  // a keyboard is normal at 1000px.
+  useEffect(() => {
+    const key = (e: KeyboardEvent) => e.key === "Escape" && close();
+    window.addEventListener("keydown", key);
+    return () => window.removeEventListener("keydown", key);
+  }, [close]);
+
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col bg-ground">
+      {/* The inset goes on the wrapper, not on the row. A fixed height with
+          `box-sizing: border-box` absorbs padding rather than growing by it, so
+          the two together squash the bar's contents under the notch instead of
+          clearing it. */}
+      <header className="shrink-0 border-b border-line bg-panel pt-[env(safe-area-inset-top)]">
+        <div className="flex h-13 items-center gap-1 px-1">
+          <button
+            onClick={close}
+            aria-label="Back"
+            className="grid h-11 w-11 shrink-0 place-items-center rounded-md text-dim transition-colors hover:bg-raise hover:text-bone"
+          >
+            <Icon of={ChevronLeft} size={20} />
+          </button>
+          <div className="min-w-0 flex-1 px-1">
+            <p className="truncate font-mono text-ui text-bone">{title(overlay)}</p>
+            {overlay.kind !== "preview" && (
+              <p className="truncate font-mono text-micro text-mute">{overlay.path}</p>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {/* Each of these draws its own bar of controls, which is what it always
+          did in a tab. `bare` drops the parts that only make sense beside
+          something else — opening in a split, mainly. */}
+      <div className="relative min-h-0 flex-1">
+        {overlay.kind === "file" && <FileTab sessionId={sessionId} path={overlay.path} />}
+        {overlay.kind === "diff" && <DiffTab sessionId={sessionId} path={overlay.path} bare />}
+        {overlay.kind === "preview" && <PreviewTab sessionId={sessionId} port={overlay.port} />}
+      </div>
+    </div>
+  );
+}
+
+function title(overlay: Overlay): string {
+  return overlay.kind === "preview" ? `Preview ${overlay.port}` : leafOf(overlay.path);
+}

--- a/web/components/workspace/RenameWorkspace.tsx
+++ b/web/components/workspace/RenameWorkspace.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * Giving a workspace a name you will recognise later.
+ *
+ * The control plane has taken a new name since sessions could be renamed, and
+ * nothing in the interface has ever asked for one — so every workspace has
+ * carried whatever it was called when it was cut, which for a workspace
+ * started from an issue is a slug and for one started from a sentence is the
+ * first few words of that sentence.
+ *
+ * That is survivable on a desk, where the rail shows the branch under the name
+ * and there is room for both. It is not survivable on a phone, where the name
+ * is the header, the header is how you know which workspace you are in, and
+ * six of them called `agent/feat-…` are the same header six times.
+ */
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useRenameSession,
+  getGetSessionQueryKey,
+  getListSessionsQueryKey,
+} from "@/src/api/generated/sessions/sessions";
+import type { Session } from "@/src/api/generated/model";
+import { Modal } from "@/components/Modal";
+import { ApiError } from "@/src/api/http";
+
+export function RenameWorkspace({
+  session,
+  onClose,
+}: {
+  session: Session;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(session.name ?? "");
+  const [trouble, setTrouble] = useState<string | null>(null);
+  const cache = useQueryClient();
+  const rename = useRenameSession();
+
+  const said = name.trim();
+  const ok = said.length > 0 && said !== session.name;
+
+  const go = () => {
+    if (!ok) return;
+    setTrouble(null);
+    rename.mutate(
+      { id: session.id, data: { name: said } },
+      {
+        onSuccess: () => {
+          cache.invalidateQueries({ queryKey: getGetSessionQueryKey(session.id) });
+          cache.invalidateQueries({ queryKey: getListSessionsQueryKey() });
+          onClose();
+        },
+        onError: (e) =>
+          setTrouble(e instanceof ApiError ? e.message : "That didn't work."),
+      },
+    );
+  };
+
+  return (
+    <Modal title="Rename this workspace" onClose={onClose}>
+      <label htmlFor="workspace-name" className="eyebrow mb-1.5 block">
+        Name
+      </label>
+      <input
+        id="workspace-name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && go()}
+        autoFocus
+        maxLength={80}
+        className="min-h-[44px] w-full rounded-md border border-line bg-ground px-3 text-ui text-text focus:border-dim focus:outline-none"
+      />
+
+      {/* What does not change, said before somebody wonders. A name is ours;
+          the branch is git's, and renaming one here would be a lie about the
+          other. */}
+      <p className="mt-2 font-mono text-micro text-mute">⑂ {session.branch ?? "no branch"}</p>
+      <p className="mt-1 text-meta leading-[1.55] text-mute">
+        Only what it is called here. The branch and the worktree keep their own names.
+      </p>
+
+      {trouble && <p className="mt-3 text-meta text-brick">{trouble}</p>}
+
+      <button
+        onClick={go}
+        disabled={!ok || rename.isPending}
+        className="mt-4 min-h-[44px] w-full rounded-md bg-bone text-ui font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
+      >
+        {rename.isPending ? "Renaming…" : "Rename"}
+      </button>
+    </Modal>
+  );
+}

--- a/web/components/workspace/ShipPanel.tsx
+++ b/web/components/workspace/ShipPanel.tsx
@@ -176,7 +176,7 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
                 href={l.url}
                 target="_blank"
                 rel="noreferrer"
-                className={`flex items-center justify-center gap-1.5 rounded-md border py-2 text-meta font-medium transition-opacity hover:opacity-80 ${
+                className={`flex min-h-[44px] items-center justify-center gap-1.5 rounded-md border py-2 text-meta font-medium transition-opacity hover:opacity-80 ${
                   ship.stage === "open"
                     ? "border-sage-deep bg-sage-tint text-sage"
                     : "border-line text-dim"
@@ -196,7 +196,7 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
                 (keeping.length === 0 && ship.stage === "uncommitted")
               }
               title={ship.blocked ?? ship.label}
-              className="w-full rounded-md bg-bone py-2 text-meta font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
+              className="min-h-[44px] w-full rounded-md bg-bone py-2 text-meta font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
             >
               {push.isPending ? "Working…" : ship.label}
             </button>
@@ -207,7 +207,7 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
         )}
       </div>
 
-      <div className="min-h-0 border-t border-line px-1 pt-1 pb-2">
+      <div className="min-h-0 border-t border-line px-1 pt-1 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         <Fold
           label={done(ship) ? "Went in" : "Going in"}
           count={keeping.length}
@@ -226,6 +226,10 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
                 onClick={() => openTab.diff(f.path)}
                 title={`${f.path} — open the diff`}
                 lead={
+                  // The glyph is 13px and the target is 44. This is the one
+                  // control on the screen that decides what does and does not
+                  // go into a commit, and a near miss opens the diff instead —
+                  // which looks like the tick simply not working.
                   <button
                     onClick={() =>
                       setDropped((held) => {
@@ -237,7 +241,7 @@ export function ShipPanel({ sessionId }: { sessionId: string }) {
                     }
                     title={going ? "Leave this one out" : "Put this one back"}
                     aria-label={going ? `Leave out ${f.path}` : `Include ${f.path}`}
-                    className={`shrink-0 text-meta transition-colors ${
+                    className={`-my-2 grid h-11 w-8 shrink-0 place-items-center text-meta transition-colors xl:-my-1 xl:h-7 ${
                       going ? "text-sage" : "text-mute hover:text-dim"
                     }`}
                   >

--- a/web/components/workspace/ShipSheet.tsx
+++ b/web/components/workspace/ShipSheet.tsx
@@ -260,7 +260,74 @@ export function ShipSheet({
   const trailer = trailerFor(refs, within);
 
   return (
-    <Modal title="Commit & open pull request" onClose={onClose} wide>
+    <Modal
+      title="Commit & open pull request"
+      onClose={onClose}
+      wide
+      floor={
+        /* The decision used to be the last thing in the body, which on a desk
+           is the bottom of a card you can see all of. On a phone the body is a
+           title, a description, a list of issues and a trailer — so the button
+           that does the thing was several scrolls below the fold, under
+           whatever the keyboard was covering. It is the floor now, on both,
+           and `Modal` pins it above the home indicator.
+
+           Wrapping rather than one row: "Open as a draft", a sentence about
+           what will happen, and three buttons do not fit across 375px, and the
+           sentence is the part that should give way. */
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          {opening && !went && (
+            <label className="flex min-h-[44px] cursor-pointer items-center gap-2 text-meta text-dim">
+              <input
+                type="checkbox"
+                checked={draft}
+                onChange={(e) => setDraft(e.target.checked)}
+                className="h-4 w-4 accent-bone"
+              />
+              Open as a draft
+            </label>
+          )}
+          {!went && sequence(ship.stage) && (
+            <p className="hidden min-w-0 flex-1 text-meta text-mute sm:block">
+              {sequence(ship.stage)}
+            </p>
+          )}
+
+          <div className="ml-auto flex items-center gap-2">
+            {writing && (
+              <button
+                onClick={() => {
+                  abandoned.current = true;
+                  describe.reset();
+                  window.setTimeout(() => first.current?.focus(), 0);
+                }}
+                className="min-h-[44px] px-1 text-meta text-mute transition-colors hover:text-bone"
+              >
+                Write it myself
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="min-h-[44px] rounded-md px-2.5 text-meta text-mute transition-colors hover:text-bone"
+            >
+              {went?.some((s) => s.state === "failed") ? "Close" : "Cancel"}
+            </button>
+            <button
+              onClick={go}
+              disabled={
+                busy ||
+                writing ||
+                (paths.length === 0 && ship.stage === "uncommitted")
+              }
+              title={`${ship.blocked ?? ship.label} (⌘↵)`}
+              className="min-h-[44px] rounded-md bg-bone px-4 text-meta font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
+            >
+              {busy ? "Working…" : went ? "Try again" : ship.label}
+            </button>
+          </div>
+        </div>
+      }
+    >
       <div
         onKeyDown={(e) => {
           // From anywhere in the sheet, including the body — a description is
@@ -442,58 +509,6 @@ export function ShipSheet({
           </p>
         )}
 
-        {/* ── the decision ────────────────────────────────────────── */}
-        <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-line pt-3">
-          {opening && !went && (
-            <label className="flex cursor-pointer items-center gap-1.5 text-meta text-dim">
-              <input
-                type="checkbox"
-                checked={draft}
-                onChange={(e) => setDraft(e.target.checked)}
-                className="accent-bone"
-              />
-              Open as a draft
-            </label>
-          )}
-          {!went && sequence(ship.stage) && (
-            <p className="min-w-0 flex-1 text-meta text-mute">
-              {sequence(ship.stage)}
-            </p>
-          )}
-
-          <div className="ml-auto flex items-center gap-2">
-            {writing && (
-              <button
-                onClick={() => {
-                  abandoned.current = true;
-                  describe.reset();
-                  window.setTimeout(() => first.current?.focus(), 0);
-                }}
-                className="text-meta text-mute transition-colors hover:text-bone"
-              >
-                Write it myself
-              </button>
-            )}
-            <button
-              onClick={onClose}
-              className="rounded-md px-2.5 py-1.5 text-meta text-mute transition-colors hover:text-bone"
-            >
-              {went?.some((s) => s.state === "failed") ? "Close" : "Cancel"}
-            </button>
-            <button
-              onClick={go}
-              disabled={
-                busy ||
-                writing ||
-                (paths.length === 0 && ship.stage === "uncommitted")
-              }
-              title={`${ship.blocked ?? ship.label} (⌘↵)`}
-              className="rounded-md bg-bone px-3 py-1.5 text-meta font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
-            >
-              {busy ? "Working…" : went ? "Try again" : ship.label}
-            </button>
-          </div>
-        </div>
       </div>
     </Modal>
   );

--- a/web/components/workspace/StartAgent.tsx
+++ b/web/components/workspace/StartAgent.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * Starting another agent in a workspace, wherever that is asked for.
+ *
+ * Every agent the fleet knows about, gated on the machine *this workspace* is
+ * on — a workspace is one directory on one host, so an agent anywhere else
+ * could not see it, and there is no choosing.
+ *
+ * Unavailable ones stay listed and say why. Vanishing from a menu looks like
+ * the thing does not exist and leaves nowhere to learn what is missing, which
+ * is the same rule the create dialog follows.
+ *
+ * Lifted out of `TabBar` when the phone grew a `⋯` menu that offers the same
+ * thing. The list, the availability rule and the reasons it prints are one
+ * piece of knowledge and were about to become two.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useCreateSession,
+  useGetSession,
+  getListSessionsQueryKey,
+} from "@/src/api/generated/sessions/sessions";
+import { useListAgents } from "@/src/api/generated/agents/agents";
+import { useListHosts } from "@/src/api/generated/hosts/hosts";
+import type { AgentView } from "@/src/api/generated/model";
+import { useCurrentSession } from "@/src/workspace/tabs";
+
+/**
+ * Why this agent cannot be started here, or nothing.
+ *
+ * The same two questions the create dialog asks, in the same order: is it on
+ * the machine at all, and can it authenticate there. A subscription lives in
+ * the agent's own config on the host it was signed in on, so one machine being
+ * signed in says nothing about another.
+ */
+export function unavailable(
+  agent: AgentView,
+  hostId?: string,
+  hostName?: string,
+): string | undefined {
+  if (!agent.supported) return "Firetower has no driver for it yet";
+  if (!hostId) return "this workspace's host is gone";
+
+  const here = agent.hosts.find((h) => h.hostId === hostId);
+  if (!here?.installed) return `not installed on ${hostName ?? "that machine"}`;
+  if (!agent.needsCredential) return undefined;
+  if (here.loggedIn === true || agent.credentialSet) return undefined;
+  return "no credentials for it there";
+}
+
+/** One row per agent, with the reason it cannot be started where there is one. */
+export function useAgentChoices() {
+  // The session you are in *is* the workspace: a workspace takes the id of the
+  // session it was split from, and that is what the tab set is keyed by. So the
+  // id is known without waiting for anything.
+  const workspaceId = useCurrentSession() ?? undefined;
+  const { data: session } = useGetSession(workspaceId ?? "", {
+    query: { enabled: !!workspaceId },
+  });
+  const { data: agents = [], isPending, isError, refetch } = useListAgents();
+  const { data: hosts = [] } = useListHosts();
+
+  // Only needed to say *why* one is unavailable. Absent while it loads, which
+  // reads as "we cannot tell yet" rather than hiding the row.
+  const host = hosts.find((h) => h.id === session?.hostId);
+
+  return {
+    workspaceId,
+    isPending,
+    isError,
+    refetch,
+    choices: agents.map((agent) => ({
+      agent,
+      why: session ? unavailable(agent, host?.id, host?.name) : undefined,
+    })),
+  };
+}
+
+/**
+ * Create the run, then hand back its id so the caller can show it.
+ *
+ * Awaited per call rather than answered in a mutation callback. Each agent is
+ * an independent run and several may be starting at once; one observer's
+ * `onSuccess` fires for the newest call, so starting three quickly meant the
+ * first two were created and never shown — which looked like a cap on how many
+ * a workspace takes.
+ */
+export function useStartAgent() {
+  const start = useCreateSession();
+  const cache = useQueryClient();
+
+  return async (workspaceId: string, agent: AgentView["kind"]): Promise<string> => {
+    const made = await start.mutateAsync({ data: { workspaceId, agent } });
+    cache.invalidateQueries({ queryKey: getListSessionsQueryKey() });
+    return made.id;
+  };
+}

--- a/web/components/workspace/StatusSheet.tsx
+++ b/web/components/workspace/StatusSheet.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * What this session is doing, when there is no panel to keep it in.
+ *
+ * On a desk the answer is a permanent line at the foot of the `Inspector` —
+ * one row, under every view, that does not move. Below `xl` there is no
+ * Inspector, and putting that line in the header instead would spend a row of
+ * a phone on a sentence that is usually "Ready".
+ *
+ * So the status light in the header is the control, and this is what it opens.
+ * The light is already the thing that means "state"; making it the way to more
+ * of it is cheaper than a fourth glyph in a bar that has three.
+ *
+ * It reuses `Doing` rather than restating it. The bring-up steps, the label
+ * under them and the rule for when a workspace is finished enough to be worth
+ * closing are decisions, and they should not exist in two places that can
+ * disagree.
+ */
+
+import { Modal } from "@/components/Modal";
+import { Doing } from "./Inspector";
+
+export function StatusSheet({
+  sessionId,
+  onClose,
+}: {
+  sessionId: string;
+  onClose: () => void;
+}) {
+  return (
+    <Modal title="Status" onClose={onClose}>
+      {/* `Doing` draws its own top border, which is right at the foot of a
+          panel and wrong as the first thing in a sheet. */}
+      <div className="-mt-2 [&>div]:border-t-0 [&>div]:px-0">
+        <Doing sessionId={sessionId} />
+      </div>
+    </Modal>
+  );
+}

--- a/web/components/workspace/TabBar.tsx
+++ b/web/components/workspace/TabBar.tsx
@@ -4,13 +4,11 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useGetSession,
-  useCreateSession,
   useDestroySession,
   getListSessionsQueryKey,
 } from "@/src/api/generated/sessions/sessions";
-import { useListAgents } from "@/src/api/generated/agents/agents";
-import { useListHosts } from "@/src/api/generated/hosts/hosts";
 import type { AgentView } from "@/src/api/generated/model";
+import { useAgentChoices, useStartAgent } from "./StartAgent";
 import { AgentMark, AGENT_SHORT } from "@/components/AgentMark";
 import { FileGlyph } from "@/components/FileGlyph";
 import { Signal } from "@/components/Signal";
@@ -239,7 +237,6 @@ function NewTab() {
   const [at, setAt] = useState({ top: 0, left: 0 });
   const opener = useOpen();
   const { open: openTab } = useTabs();
-  const cache = useQueryClient();
 
   // Owned here rather than in the menu below it. React Query drops a
   // component's mutation callbacks when it unmounts, and closing the menu
@@ -249,21 +246,13 @@ function NewTab() {
   //
   // This button is part of the strip and never goes away, so its callback
   // always runs.
-  // Not gated on `isPending`, and not opened from the mutation's own callback.
-  //
-  // Each agent is an independent run and several may be starting at once, so
-  // disabling the list while one was in flight left later clicks landing on a
-  // dead button. And one observer's `onSuccess` fires for the newest call —
-  // start three quickly and the first two never opened a tab, though all three
-  // runs were created. Both looked like a cap on how many a workspace takes.
-  //
-  // Awaiting the call answers per click, whatever else is in flight.
-  const start = useCreateSession();
+  // Not gated on `isPending`, and not opened from the mutation's own callback —
+  // see `useStartAgent`, which awaits per call for the reason.
+  const start = useStartAgent();
 
   const begin = async (workspaceId: string, agent: AgentView["kind"]) => {
-    const made = await start.mutateAsync({ data: { workspaceId, agent } });
-    cache.invalidateQueries({ queryKey: getListSessionsQueryKey() });
-    openTab({ id: addressOf.run(made.id), kind: "run", sessionId: made.id });
+    const id = await start(workspaceId, agent);
+    openTab({ id: addressOf.run(id), kind: "run", sessionId: id });
   };
 
   // Before paint, so it never shows for a frame in the wrong place.
@@ -382,44 +371,18 @@ function Preview({ onOpen }: { onOpen: (port: number) => void }) {
 }
 
 /**
- * Starting another agent in this workspace.
+ * Starting another agent in this workspace, as rows of this menu.
  *
- * Every agent the fleet knows about, gated on the machine *this workspace* is
- * on — a workspace is one directory on one host, so an agent anywhere else
- * could not see it, and there is no choosing.
- *
- * Unavailable ones stay listed and say why. Vanishing from a menu looks like
- * the thing does not exist and leaves nowhere to learn what is missing, which
- * is the same rule the create dialog follows.
+ * The list itself and the rule for whether an agent can run here are in
+ * `StartAgent`, shared with the `⋯` menu a workspace draws below `xl`. This is
+ * only the drawing.
  */
 function Agents({
   onStart,
 }: {
   onStart: (workspaceId: string, agent: AgentView["kind"]) => void;
 }) {
-  // The session you are in *is* the workspace: a workspace takes the id of the
-  // session it was split from, and that is what the tab set is keyed by. So the
-  // id is known without waiting for anything — which matters, because this
-  // renders the moment the menu opens and the session may not be cached yet.
-  //
-  // Depending on that query meant the whole section returned `null` while it
-  // loaded, so the menu opened with the agents simply absent and clicking where
-  // they should have been did nothing at all.
-  const workspaceId = useCurrentSession() ?? undefined;
-  const { data: session } = useGetSession(workspaceId ?? "", {
-    query: { enabled: !!workspaceId },
-  });
-  const {
-    data: agents = [],
-    isPending,
-    isError,
-    refetch,
-  } = useListAgents();
-  const { data: hosts = [] } = useListHosts();
-
-  // Only needed to say *why* one is unavailable. Absent while it loads, which
-  // reads as "we cannot tell yet" rather than hiding the row.
-  const host = hosts.find((h) => h.id === session?.hostId);
+  const { workspaceId, choices, isPending, isError, refetch } = useAgentChoices();
 
   if (!workspaceId) return null;
 
@@ -449,47 +412,25 @@ function Agents({
         </button>
       )}
 
-      {!isPending && !isError && agents.length === 0 && (
+      {!isPending && !isError && choices.length === 0 && (
         <p className="px-2 pb-1.5 text-meta text-mute">
           No agents configured. Add one on the Agents screen.
         </p>
       )}
 
-      {agents.map((a) => {
-        const why = session ? unavailable(a, host?.id, host?.name) : undefined;
-        return (
-          <Choice
-            key={a.kind}
-            glyph=""
-            mark={a.kind}
-            label={a.label}
-            hint={why ?? "In this workspace, on its branch"}
-            disabled={!!why}
-            onClick={() => onStart(workspaceId, a.kind)}
-          />
-        );
-      })}
+      {choices.map(({ agent, why }) => (
+        <Choice
+          key={agent.kind}
+          glyph=""
+          mark={agent.kind}
+          label={agent.label}
+          hint={why ?? "In this workspace, on its branch"}
+          disabled={!!why}
+          onClick={() => onStart(workspaceId, agent.kind)}
+        />
+      ))}
     </>
   );
-}
-
-/**
- * Why this agent cannot be started here, or nothing.
- *
- * The same two questions the create dialog asks, in the same order: is it on
- * the machine at all, and can it authenticate there. A subscription lives in
- * the agent's own config on the host it was signed in on, so one machine being
- * signed in says nothing about another.
- */
-function unavailable(agent: AgentView, hostId?: string, hostName?: string): string | undefined {
-  if (!agent.supported) return "Firetower has no driver for it yet";
-  if (!hostId) return "this workspace's host is gone";
-
-  const here = agent.hosts.find((h) => h.hostId === hostId);
-  if (!here?.installed) return `not installed on ${hostName ?? "that machine"}`;
-  if (!agent.needsCredential) return undefined;
-  if (here.loggedIn === true || agent.credentialSet) return undefined;
-  return "no credentials for it there";
 }
 
 function Choice({

--- a/web/components/workspace/Tree.tsx
+++ b/web/components/workspace/Tree.tsx
@@ -261,7 +261,10 @@ function Node({
           onClick={() => (foldable ? toggle(path) : onOpen(path))}
           data-path={path}
           title={path}
-          className={`flex h-6 w-full items-center rounded-sm pr-1.5 text-left transition-colors ${
+          // 24px is a tree row on a desk and a miss on a phone. The guides
+          // are `h-full`, so growing the row grows them with it and a deep
+          // branch still reads as one trunk.
+          className={`flex h-6 w-full items-center rounded-sm pr-1.5 text-left transition-colors max-xl:h-11 ${
             active ? "bg-raise" : "hover:bg-raise/60"
           }`}
         >

--- a/web/components/workspace/Views.tsx
+++ b/web/components/workspace/Views.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * Files, Changes and Ship — the three views, without a frame around them.
+ *
+ * They used to be the inside of `Inspector`, which meant they were the inside
+ * of a 320px panel on the right of a wide window, and that was the only place
+ * they could ever be. Below `xl` there is no room for that panel, so there was
+ * nothing: an iPad in landscape — every model but the 13" is under 1280px
+ * there — had no route to a diff or a pull request at all.
+ *
+ * So the views moved out and the panel became one of two frames around them.
+ * The other is the switcher in a workspace's header. Neither frame knows what
+ * is inside it and the views do not know which frame they are in; the only
+ * thing that differs is how wide they get to be, and they were built to be
+ * narrow.
+ *
+ * Nothing here is a viewer. A file opens a file tab, a change opens a diff
+ * tab — in the pane on a desk, as a pushed screen on a phone.
+ */
+
+import { useSessionDiff } from "@/src/api/generated/sessions/sessions";
+import { useOpen } from "@/src/workspace/tabs";
+import type { View } from "@/src/workspace/panel";
+import { PathRow, Counts } from "./PathRow";
+import { Tree } from "./Tree";
+import { ShipPanel } from "./ShipPanel";
+
+export function WorkspaceView({
+  view,
+  sessionId,
+  changed,
+  onShip,
+}: {
+  view: View;
+  sessionId: string;
+  /** Which paths the agent has touched, for the marks in the tree. */
+  changed: Set<string>;
+  /** Bring Ship forward — a panel view on a desk, a screen on a phone. */
+  onShip: () => void;
+}) {
+  if (view === "files") return <Tree sessionId={sessionId} changed={changed} />;
+  if (view === "changes") return <Changes sessionId={sessionId} onShip={onShip} />;
+  return <ShipPanel sessionId={sessionId} />;
+}
+
+/** What is in the workspace that is not safely elsewhere. */
+export function Changes({
+  sessionId,
+  onShip,
+}: {
+  sessionId: string;
+  onShip: () => void;
+}) {
+  const { data: files = [], isLoading } = useSessionDiff(sessionId, undefined, {
+    query: { refetchInterval: 8_000 },
+  });
+  const open = useOpen();
+
+  const added = files.reduce((n, f) => n + f.added, 0);
+  const removed = files.reduce((n, f) => n + f.removed, 0);
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center gap-2 border-b border-line px-3 py-1.5">
+        <span className="eyebrow">Changes</span>
+        <span className="ml-auto font-mono text-micro text-mute">
+          {isLoading ? "…" : files.length === 0 ? "none" : `${files.length} files`}
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-1.5 py-1">
+        {files.map((f) => (
+          <PathRow
+            key={f.path}
+            path={f.path}
+            onClick={() => open.diff(f.path)}
+            trail={<Counts added={f.added} removed={f.removed} />}
+          />
+        ))}
+
+        {!isLoading && files.length === 0 && <Line>Nothing has changed yet.</Line>}
+      </div>
+
+      {files.length > 0 && (
+        <div className="shrink-0 border-t border-line px-3 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+          <p className="mb-2 font-mono text-micro text-mute">
+            <span className="text-sage">+{added}</span>{" "}
+            <span className="text-brick">−{removed}</span>
+          </p>
+          <button
+            onClick={onShip}
+            className="min-h-[44px] w-full rounded-md border border-line text-meta text-dim transition-colors hover:border-line hover:text-bone"
+          >
+            Review &amp; ship →
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Line({ children }: { children: React.ReactNode }) {
+  return <p className="px-1.5 py-1 text-meta text-mute">{children}</p>;
+}

--- a/web/components/workspace/Workspace.tsx
+++ b/web/components/workspace/Workspace.tsx
@@ -22,6 +22,9 @@ import {
   type Tab,
 } from "@/src/workspace/tabs";
 import { useWorkbenchKeys } from "@/src/workspace/keys";
+import { useHasPanel, useHasRail } from "@/src/workspace/layout";
+import { resetScreen } from "@/src/workspace/screen";
+import { OneColumn } from "./OneColumn";
 
 /**
  * The whole interface: sessions on the left, what you are reading in the
@@ -47,6 +50,7 @@ function Bench({ initialSession }: { initialSession?: string }) {
   const router = useRouter();
   const { enter } = useTabs();
   const current = useCurrentSession();
+  const hasPanel = useHasPanel();
   /** The repository the composer should start on, when it was opened from one. */
   // The same query the rail runs, so this costs nothing — but it is the only
   // place that can say the whole thing is unreachable rather than empty.
@@ -87,7 +91,33 @@ function Bench({ initialSession }: { initialSession?: string }) {
     if (entered.current) router.replace("/");
   }, [current, router]);
 
+  // Below `xl` a workspace shows one of four things and remembers which. A
+  // different workspace should open on its conversation rather than on
+  // whichever view the last one was left on — landing on a file tree because
+  // that is where you were an hour ago is the app losing your place, not
+  // keeping it.
+  useEffect(() => {
+    if (current) resetScreen();
+  }, [current]);
+
   if (isError) return <Unreachable />;
+
+  /* One column below `xl`, where there is no room for a panel beside the work
+     — a phone, and every iPad but the 13" in landscape. Chosen here rather
+     than with a Tailwind prefix because the two layouts are different trees,
+     not the same tree at two widths: rendering both and hiding one would mean
+     two `ShipPanel`s with two sets of ticked files, disagreeing about what is
+     about to be committed. */
+  if (!hasPanel) {
+    if (!current) {
+      return (
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <Blank />
+        </div>
+      );
+    }
+    return <OneColumn sessionId={current} onBack={() => router.push("/")} />;
+  }
 
   return (
     <div className="flex min-w-0 flex-1 overflow-hidden">
@@ -220,11 +250,20 @@ function Unreachable() {
   );
 }
 
+/**
+ * A workspace screen with no workspace in it.
+ *
+ * "On the left" is true at a desk and a lie on a phone, where the rail is a
+ * drawer behind the `☰` and there is nothing to the left of anything.
+ */
 function Blank() {
+  const hasRail = useHasRail();
   return (
     <div className="flex h-full items-center justify-center px-8">
       <p className="max-w-[40ch] text-center text-ui text-mute">
-        Pick a session on the left, or start one.
+        {hasRail
+          ? "Pick a session on the left, or start one."
+          : "Pick a workspace from the menu, or start one."}
       </p>
     </div>
   );

--- a/web/components/workspace/WorkspaceHeader.tsx
+++ b/web/components/workspace/WorkspaceHeader.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * Where you are, how you get back, and which of the three you are looking at.
+ *
+ * Only below `xl`. Above it the rail names the workspace, the panel holds the
+ * views, and a header would be a row of chrome restating the room — which is
+ * exactly the bar that was deleted from `SessionTab`, and it is not coming
+ * back to the desk.
+ *
+ * Below `xl` none of that is on screen. There is no rail to say which
+ * workspace this is, no panel to reach Ship from, and — on a phone — no
+ * browser chrome to press Back in, because the address bar hides itself the
+ * moment you scroll. So this is the whole of the furniture, in one 52px bar
+ * and one 40px row.
+ *
+ * ## The switcher is at the top
+ *
+ * A bottom tab bar is the obvious mobile answer and it is wrong here, because
+ * the bottom is spoken for. The composer lives there, it is 90px, and a 44px
+ * bar under it is 134px of chrome beneath a transcript on a screen with about
+ * 300px left above the keyboard. Switching view happens a few times an hour
+ * and typing happens constantly, so the frequent thing keeps the reachable
+ * place. It is also where the desk draws its tab strip, which makes this one
+ * idea at two sizes rather than two ideas.
+ */
+
+import { useState } from "react";
+import { ChevronLeft, Menu, MoreHorizontal } from "lucide-react";
+import { useGetSession } from "@/src/api/generated/sessions/sessions";
+import { Icon } from "@/components/ui";
+import { Signal } from "@/components/Signal";
+import { useDrawer } from "@/src/workspace/drawer";
+import { useHasRail } from "@/src/workspace/layout";
+import { SCREENS, useScreen } from "@/src/workspace/screen";
+import { WorkspaceMenu } from "./WorkspaceMenu";
+import { StatusSheet } from "./StatusSheet";
+
+export function WorkspaceHeader({
+  sessionId,
+  changed,
+  onBack,
+}: {
+  sessionId: string;
+  /** How many files the agent has touched, for the count on `Diff`. */
+  changed: number;
+  onBack: () => void;
+}) {
+  const { data: session } = useGetSession(sessionId);
+  const { show: openDrawer } = useDrawer();
+  const hasRail = useHasRail();
+  const [menu, setMenu] = useState(false);
+  const [status, setStatus] = useState(false);
+
+  return (
+    <header className="shrink-0 border-b border-line bg-panel pt-[env(safe-area-inset-top)]">
+      <div className="flex h-13 items-center gap-0.5 px-1">
+        {/* Back on a phone, the menu on a tablet.
+            They are the same button in the same place doing the same job —
+            "out of here" — and which one it is depends on whether there is
+            already a rail on screen to go out *to*. A `‹` beside a rail that
+            is permanently showing the fleet would be a second way to do what
+            the rail does. */}
+        {hasRail ? (
+          <Tap label="Open the menu" onClick={openDrawer}>
+            <Icon of={Menu} size={16} />
+          </Tap>
+        ) : (
+          <Tap label="Back to the dashboard" onClick={onBack}>
+            <Icon of={ChevronLeft} size={20} />
+          </Tap>
+        )}
+
+        <div className="min-w-0 flex-1 px-1">
+          <p className="truncate text-ui font-medium text-bone">
+            {session?.name ?? "Workspace"}
+          </p>
+          <p className="truncate font-mono text-micro text-mute">
+            {session?.repo ?? session?.branch ?? "no repository"}
+          </p>
+        </div>
+
+        {/* The light is a button. What the session is doing lives at the foot
+            of the panel on a desk, and the panel is not here — so the thing
+            that already means "state" is what opens it. */}
+        <Tap label="What this session is doing" onClick={() => setStatus(true)}>
+          <Signal status={session?.status ?? "Starting"} size={8} />
+        </Tap>
+
+        <Tap label="More" onClick={() => setMenu(true)}>
+          <Icon of={MoreHorizontal} size={16} />
+        </Tap>
+      </div>
+
+      <ViewBar changed={changed} />
+
+      {menu && <WorkspaceMenu sessionId={sessionId} onClose={() => setMenu(false)} />}
+      {status && <StatusSheet sessionId={sessionId} onClose={() => setStatus(false)} />}
+    </header>
+  );
+}
+
+/**
+ * Chat, Diff, Ship.
+ *
+ * Three, not the six things a workspace can show. Files, a terminal, a preview
+ * and a second agent are in the `⋯` menu, because the two errands somebody
+ * opens this on a phone for are answering an agent and shipping what it wrote,
+ * and burying the rest is the point rather than a compromise.
+ */
+function ViewBar({ changed }: { changed: number }) {
+  const { screen, show } = useScreen();
+
+  return (
+    <div className="flex items-stretch px-1">
+      {SCREENS.map((s) => (
+        <Tab key={s.id} on={screen === s.id} onClick={() => show(s.id)} label={s.label}>
+          {s.id === "changes" && changed > 0 && (
+            <span className="rounded-full bg-bone px-1 font-mono text-micro leading-[15px] text-ground">
+              {changed > 99 ? "99+" : changed}
+            </span>
+          )}
+        </Tab>
+      ))}
+    </div>
+  );
+}
+
+function Tab({
+  on,
+  onClick,
+  label,
+  children,
+}: {
+  on: boolean;
+  onClick: () => void;
+  label: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={on}
+      // Two pixels of bone along the bottom edge, which is the same mark the
+      // desk's tab strip puts along the top of the tab you are on.
+      className={`relative flex min-h-[44px] flex-1 items-center justify-center gap-1.5 text-ui transition-colors ${
+        on
+          ? "text-bone after:absolute after:inset-x-3 after:bottom-0 after:h-[2px] after:bg-bone after:content-['']"
+          : "text-mute hover:text-dim"
+      }`}
+    >
+      {label}
+      {children}
+    </button>
+  );
+}
+
+/** A 44px target around a glyph that is nowhere near 44px. */
+function Tap({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className="grid h-11 w-11 shrink-0 place-items-center rounded-md text-dim transition-colors hover:bg-raise hover:text-bone"
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/components/workspace/WorkspaceMenu.tsx
+++ b/web/components/workspace/WorkspaceMenu.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+/**
+ * Everything a workspace can do that is not Chat, Diff or Ship.
+ *
+ * Three in the switcher and the rest here. That split is the whole argument
+ * for the phone: the two errands somebody opens Firetower on a train for are
+ * answering an agent and shipping what it wrote, and a file tree, a port
+ * preview and a second agent are neither. Burying them is the point rather
+ * than a compromise, and nothing is unreachable.
+ *
+ * A sheet rather than a dropdown. `SessionMenu` is a dropdown that does some
+ * of this on a desk, and its shape does not travel: it anchors itself to a
+ * trigger with a measured rectangle, it is 292px wide, and its rows are 32px.
+ * What survives the trip is the *actions* — stopping an agent, ending a
+ * workspace — and those are the hooks both call, not the drawing.
+ *
+ * ## No terminal
+ *
+ * An xterm with no Esc, no Tab and no Ctrl is not a terminal; it is a picture
+ * of one. A terminal opened at a desk is simply not reachable here, and is
+ * still there when you get back to a real keyboard.
+ */
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useGetSession,
+  useStopSession,
+  getGetSessionQueryKey,
+  getSessionWorkQueryKey,
+} from "@/src/api/generated/sessions/sessions";
+import type { AgentView } from "@/src/api/generated/model";
+import { Modal } from "@/components/Modal";
+import { AgentMark } from "@/components/AgentMark";
+import { ApiError } from "@/src/api/http";
+import { useOpen } from "@/src/workspace/tabs";
+import { useScreen } from "@/src/workspace/screen";
+import { useAgentChoices, useStartAgent } from "./StartAgent";
+import { CloseWorkspace } from "./CloseWorkspace";
+import { RenameWorkspace } from "./RenameWorkspace";
+
+export function WorkspaceMenu({
+  sessionId,
+  onClose,
+}: {
+  sessionId: string;
+  onClose: () => void;
+}) {
+  const { data: session } = useGetSession(sessionId);
+  const { show } = useScreen();
+  const open = useOpen();
+  const cache = useQueryClient();
+  const stop = useStopSession();
+
+  const [asking, setAsking] = useState<"preview" | "agents" | "rename" | null>(null);
+  const [trouble, setTrouble] = useState<string | null>(null);
+
+  const running = session?.status === "Working" || session?.status === "Starting";
+
+  /* One sheet, whose contents change — rather than one sheet swapped for
+     another. Below `md` a sheet takes a history entry so the system Back
+     button closes it (see `useDismissible`), and replacing the component
+     unmounts one layer and mounts another in the same commit: the first pops
+     its entry, the second pushes one, and the pop lands on the push. Back then
+     left the workspace instead of returning to the menu.
+
+     Keeping the sheet mounted also reads better. Asking which port is a step
+     inside "more", not a different place, and the title saying so while the
+     frame stays put is what a step looks like. */
+  const title =
+    asking === "preview"
+      ? "Preview a port"
+      : asking === "agents"
+        ? "Start an agent"
+        : (session?.name ?? "Workspace");
+
+  /* ✕ and Back step back one level rather than closing outright, so the way
+     out of "which port?" is the way out of everything else on the screen. */
+  const back = () => (asking ? setAsking(null) : onClose());
+
+  return (
+    <>
+    <Modal title={title} onClose={back}>
+      {asking === "preview" && (
+        <AskPort
+          onOpen={(port) => {
+            onClose();
+            open.preview(port);
+          }}
+        />
+      )}
+
+      {asking === "agents" && <AskAgent onClose={onClose} />}
+
+      {asking === null && (
+      <div className="-mx-2 flex flex-col">
+        <Item
+          label="Files"
+          hint="Everything in the worktree"
+          onClick={() => {
+            onClose();
+            show("files");
+          }}
+        />
+        <Item
+          label="Preview a port"
+          hint="The application running in here"
+          onClick={() => setAsking("preview")}
+        />
+        <Item
+          label="Start another agent"
+          hint="In this workspace, on its branch"
+          onClick={() => setAsking("agents")}
+        />
+
+        <Rule />
+
+        <Item label="Rename…" onClick={() => setAsking("rename")} />
+
+        {running && (
+          <Item
+            label="Stop the agent"
+            hint={session?.repo ? "Keeps the workspace and the branch" : "Keeps the workspace"}
+            disabled={stop.isPending}
+            onClick={() =>
+              stop.mutate(
+                { id: sessionId },
+                {
+                  onSuccess: () => {
+                    cache.invalidateQueries({ queryKey: getGetSessionQueryKey(sessionId) });
+                    cache.invalidateQueries({ queryKey: getSessionWorkQueryKey(sessionId) });
+                    onClose();
+                  },
+                  onError: (e) =>
+                    setTrouble(e instanceof ApiError ? e.message : "That didn't work."),
+                },
+              )
+            }
+          />
+        )}
+
+        <Rule />
+
+        {/* The one destructive thing, under a divider and at the bottom, where
+            a thumb travelling down the list has already stopped. It brings its
+            own confirmation — see `CloseWorkspace`, which names the branch and
+            counts what is not yet pushed. */}
+        {session && (
+          <div className="px-2 pt-1">
+            <CloseWorkspace session={session} prominent />
+          </div>
+        )}
+      </div>
+      )}
+
+      {trouble && <p className="mt-3 text-meta text-brick">{trouble}</p>}
+    </Modal>
+
+    {/* Its own sheet, over this one. A layer on top of a layer is fine — each
+        takes its own history entry and Back unwinds them in order; what is not
+        fine is one layer *becoming* another, which is what the note above is
+        about. */}
+    {asking === "rename" && session && (
+      <RenameWorkspace session={session} onClose={() => setAsking(null)} />
+    )}
+    </>
+  );
+}
+
+/**
+ * Which port the application is on.
+ *
+ * A field rather than a list, for the same reason the desk's menu asks: nothing
+ * knows what is running in there until something answers, and asking is cheaper
+ * than discovering. 3000 is filled in because it is what most of them pick.
+ */
+function AskPort({ onOpen }: { onOpen: (port: number) => void }) {
+  const [port, setPort] = useState("3000");
+  const n = Number(port);
+  const ok = Number.isInteger(n) && n > 0 && n < 65536;
+
+  return (
+    <>
+      <label htmlFor="preview-port" className="eyebrow mb-1.5 block">
+        Which port is it on?
+      </label>
+      <input
+        id="preview-port"
+        value={port}
+        onChange={(e) => setPort(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && ok && onOpen(n)}
+        // A numeric keypad rather than the full alphabet, and `numeric` rather
+        // than `tel` so it is digits without a dial pad's punctuation.
+        inputMode="numeric"
+        autoFocus
+        className="min-h-[44px] w-full rounded-md border border-line bg-ground px-3 font-mono text-ui text-text focus:border-dim focus:outline-none"
+      />
+      <p className="mt-2 text-meta leading-[1.55] text-mute">
+        The application running in this workspace, on a port of its machine.
+      </p>
+
+      <button
+        onClick={() => ok && onOpen(n)}
+        disabled={!ok}
+        className="mt-4 min-h-[44px] w-full rounded-md bg-bone text-ui font-medium text-ground transition-colors hover:bg-white disabled:bg-line disabled:text-mute"
+      >
+        Open
+      </button>
+    </>
+  );
+}
+
+/** The same list the desk's `+` menu offers, as a sheet. */
+function AskAgent({ onClose }: { onClose: () => void }) {
+  const { workspaceId, choices, isPending, isError, refetch } = useAgentChoices();
+  const start = useStartAgent();
+  const { show } = useScreen();
+  const [trouble, setTrouble] = useState<string | null>(null);
+
+  const begin = async (agent: AgentView["kind"]) => {
+    if (!workspaceId) return;
+    try {
+      await start(workspaceId, agent);
+      // Back to the conversation, which is where a new agent will start
+      // talking. There is no tab strip here to open it into.
+      show("chat");
+      onClose();
+    } catch (e) {
+      setTrouble(e instanceof ApiError ? e.message : "That didn't work.");
+    }
+  };
+
+  return (
+    <>
+      {isPending && (
+        <p className="text-meta text-mute" aria-busy>
+          Looking…
+        </p>
+      )}
+
+      {isError && (
+        <button
+          onClick={() => refetch()}
+          className="text-meta text-dim transition-colors hover:text-bone"
+        >
+          Couldn&rsquo;t reach the API. Retry
+        </button>
+      )}
+
+      {!isPending && !isError && choices.length === 0 && (
+        <p className="text-meta leading-[1.55] text-mute">
+          No agents configured. Add one under Configuration.
+        </p>
+      )}
+
+      <div className="-mx-2 flex flex-col">
+        {choices.map(({ agent, why }) => (
+          <Item
+            key={agent.kind}
+            mark={agent.kind}
+            label={agent.label}
+            hint={why ?? "In this workspace, on its branch"}
+            disabled={!!why}
+            onClick={() => void begin(agent.kind)}
+          />
+        ))}
+      </div>
+
+      {trouble && <p className="mt-3 text-meta text-brick">{trouble}</p>}
+    </>
+  );
+}
+
+function Rule() {
+  return <div className="my-2 border-t border-line" />;
+}
+
+/** One row. 52px, because a menu on a phone is a list of targets. */
+function Item({
+  label,
+  hint,
+  mark,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  hint?: string;
+  /** An agent's own mark, where the row is about one. */
+  mark?: React.ComponentProps<typeof AgentMark>["agent"];
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex min-h-[52px] w-full items-center gap-3 rounded-md px-2 text-left transition-colors enabled:hover:bg-raise disabled:opacity-45"
+    >
+      {mark && <AgentMark agent={mark} size={16} className="shrink-0 text-mute" />}
+      <span className="min-w-0 flex-1">
+        <span className="block text-ui text-text">{label}</span>
+        {hint && <span className="block text-meta text-mute">{hint}</span>}
+      </span>
+    </button>
+  );
+}

--- a/web/src/workspace/code.ts
+++ b/web/src/workspace/code.ts
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * How big the machine's own text is drawn, when somebody has said.
+ *
+ * This is what pinch-to-zoom was for. Taking zoom away from the workbench —
+ * see `touch.ts` — is defensible only because the one screen where a pinch was
+ * doing real work gets something better instead: a diff at 15px re-wraps to
+ * the width it has, where a pinch at 1.4× makes a wide thing wider and pushes
+ * the `+` and `−` off the left of the screen.
+ *
+ * Three sizes, not a slider. The question is "I can't read that" or "I want
+ * more on screen", and neither of them is answered by a continuum.
+ *
+ * Kept in the browser, like the panel width and the tab layout: how big
+ * somebody wants code is a fact about their eyes and their screen, not about
+ * the fleet, and it should not follow them to a different machine.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/** 13px is `--text-code`, so the default is exactly what the desk always had. */
+export const CYCLE = [13, 15, 11] as const;
+
+const KEY = "firetower.code-size";
+const watching = new Set<() => void>();
+
+let held: { raw: string | null; size: number } = { raw: null, size: CYCLE[0] };
+
+function read(): number {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(KEY);
+  } catch {
+    return CYCLE[0];
+  }
+  // Compared by the raw string, so re-parsing does not look like a change to
+  // React and re-render every open diff on every tick.
+  if (held.raw === raw) return held.size;
+
+  const asked = Number(raw);
+  // A size from an older build, or a hand-edited store, must not be able to
+  // draw a patch at 400px or at nothing.
+  const size = CYCLE.includes(asked as (typeof CYCLE)[number]) ? asked : CYCLE[0];
+  held = { raw, size };
+  return size;
+}
+
+function listen(onChange: () => void) {
+  watching.add(onChange);
+  // Another tab is another window on the same person. If they turned it up
+  // there, it is turned up here.
+  window.addEventListener("storage", onChange);
+  return () => {
+    watching.delete(onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+export function useCodeSize() {
+  const size = useSyncExternalStore(
+    listen,
+    read,
+    () => CYCLE[0],
+  );
+
+  const cycle = useCallback(() => {
+    const now = read();
+    const next = CYCLE[(CYCLE.indexOf(now as (typeof CYCLE)[number]) + 1) % CYCLE.length];
+    try {
+      window.localStorage.setItem(KEY, String(next));
+    } catch {
+      // It still works for this visit, which is the part that matters.
+    }
+    for (const tell of watching) tell();
+  }, []);
+
+  return { size, cycle };
+}

--- a/web/src/workspace/dismissible.ts
+++ b/web/src/workspace/dismissible.ts
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * A layer that the system Back button closes.
+ *
+ * On a phone, anything drawn over the screen — a drawer, a sheet, a menu — is
+ * expected to be dismissed by Back. Android has no other gesture for it, and
+ * on iOS the edge-swipe means the same thing. Without this, opening the ship
+ * sheet and pressing Back throws you out of the workspace with the sheet still
+ * notionally open, which is the worst of both.
+ *
+ * The shape is the usual one: opening pushes an entry that goes nowhere — same
+ * URL, a marker in `history.state` — so there is something for Back to pop.
+ * Popping it calls `onClose`. Closing by any other route takes the entry back
+ * out, so the layer does not leave a dead press behind it.
+ *
+ * ## What it does not do
+ *
+ * If the layer closes *because the app navigated* — `CloseWorkspace` sends you
+ * to `/` when the workspace is gone, and tapping a workspace in the drawer
+ * opens it — the entry is no longer the current one and cannot be popped
+ * without undoing that navigation. It is left in place. The cost is one Back
+ * press that appears to do nothing before the next one leaves, and the
+ * alternative is racing the router for the history stack, which is how you
+ * lose somebody's navigation rather than one press of a button.
+ *
+ * Not used above `md`. On a desk, Escape closes things and the browser's Back
+ * belongs to the browser — a modal that eats a Back press there would be the
+ * kind of cleverness that loses somebody the page they were reading.
+ */
+
+import { useEffect } from "react";
+import { useHasRail } from "./layout";
+
+/** Distinguishes nested layers, so a sheet over a drawer pops only itself. */
+let count = 0;
+
+export function useDismissible(open: boolean, onClose: () => void, kind: string) {
+  const onDesk = useHasRail();
+
+  useEffect(() => {
+    if (!open || onDesk) return;
+
+    const mark = `${kind}:${(count += 1)}`;
+    const mine = () => (window.history.state as { ftLayer?: string } | null)?.ftLayer === mark;
+
+    window.history.pushState({ ftLayer: mark }, "");
+
+    const popped = () => onClose();
+    window.addEventListener("popstate", popped);
+
+    return () => {
+      window.removeEventListener("popstate", popped);
+      // Only if the entry is still ours. Closing *by* Back has already popped
+      // it, and popping again would take the page somebody came from with it.
+      if (mine()) window.history.back();
+    };
+  }, [open, onClose, onDesk, kind]);
+}

--- a/web/src/workspace/dismissible.ts
+++ b/web/src/workspace/dismissible.ts
@@ -29,7 +29,7 @@
  * kind of cleverness that loses somebody the page they were reading.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useHasRail } from "./layout";
 
 /** Distinguishes nested layers, so a sheet over a drawer pops only itself. */
@@ -38,22 +38,54 @@ let count = 0;
 export function useDismissible(open: boolean, onClose: () => void, kind: string) {
   const onDesk = useHasRail();
 
+  // Held in a ref rather than named as a dependency. Every caller passes an
+  // inline arrow — `onClose={() => setReading(null)}` — so as a dependency it
+  // was a new function on every render of the parent, and this effect tore
+  // itself down and set itself up again each time. See below for why that was
+  // fatal rather than merely wasteful.
+  const close = useRef(onClose);
+  useEffect(() => {
+    close.current = onClose;
+  }, [onClose]);
+
   useEffect(() => {
     if (!open || onDesk) return;
 
     const mark = `${kind}:${(count += 1)}`;
     const mine = () => (window.history.state as { ftLayer?: string } | null)?.ftLayer === mark;
 
-    window.history.pushState({ ftLayer: mark }, "");
+    // Pushed a tick late, and cancelled if this effect is torn down before the
+    // tick arrives.
+    //
+    // `history.back()` in the cleanup is asynchronous: it queues a `popstate`
+    // rather than raising one. A set-up, tear-down, set-up in the same tick —
+    // which is exactly what React does in development, and what a re-render
+    // used to do — therefore pushed, called back, and pushed again, and the
+    // pop from that `back` landed a few milliseconds later on the listener the
+    // *second* set-up had just registered. It read as somebody pressing Back,
+    // so every sheet and every modal closed itself before it was ever painted.
+    //
+    // Deferring means a set-up that does not survive the tick never touches
+    // history at all, so there is no pop to misread.
+    let live = true;
+    let pushed = false;
+    const push = window.setTimeout(() => {
+      if (!live) return;
+      window.history.pushState({ ftLayer: mark }, "");
+      pushed = true;
+    }, 0);
 
-    const popped = () => onClose();
+    const popped = () => close.current();
     window.addEventListener("popstate", popped);
 
     return () => {
+      live = false;
+      window.clearTimeout(push);
       window.removeEventListener("popstate", popped);
-      // Only if the entry is still ours. Closing *by* Back has already popped
-      // it, and popping again would take the page somebody came from with it.
-      if (mine()) window.history.back();
+      // Only if we got as far as pushing, and only if the entry is still ours.
+      // Closing *by* Back has already popped it, and popping again would take
+      // the page somebody came from with it.
+      if (pushed && mine()) window.history.back();
     };
-  }, [open, onClose, onDesk, kind]);
+  }, [open, onDesk, kind]);
 }

--- a/web/src/workspace/drawer.ts
+++ b/web/src/workspace/drawer.ts
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * Whether the rail is showing, on a screen too narrow to keep it out.
+ *
+ * A module store rather than state in `Shell`, for one reason: the `☰` that
+ * opens it is not always in `Shell`. Every document page gets the bar `Shell`
+ * draws, but a workspace draws its own header — it has a `‹` and a `⋯` and a
+ * status light to fit beside the same `☰` — and that header is three levels
+ * down inside `children`. Lifting the state here is cheaper than threading a
+ * callback through `Shell`, `Workspace`, and the header.
+ *
+ * Not persisted. Whether a drawer was open is not something to remember; it is
+ * something somebody is doing right now, and a reload that came back with the
+ * menu over the page would be the app second-guessing them.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+let open = false;
+const watching = new Set<() => void>();
+
+function set(next: boolean) {
+  if (open === next) return;
+  open = next;
+  for (const tell of watching) tell();
+}
+
+function listen(onChange: () => void) {
+  watching.add(onChange);
+  return () => {
+    watching.delete(onChange);
+  };
+}
+
+export function useDrawer() {
+  const showing = useSyncExternalStore(
+    listen,
+    () => open,
+    () => false,
+  );
+
+  return {
+    open: showing,
+    show: useCallback(() => set(true), []),
+    hide: useCallback(() => set(false), []),
+  };
+}

--- a/web/src/workspace/layout.ts
+++ b/web/src/workspace/layout.ts
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * How much room there is, as two questions rather than one.
+ *
+ * The interface used to answer this with two Tailwind prefixes that happened
+ * to be in the same files: the rail was `md:flex` and the panel was `xl:flex`,
+ * and the band between them — 768 to 1279 — got the rail and no panel at all.
+ * That band is most of the iPads there are. Every one except the 13" is under
+ * 1280 in landscape, so an iPad Pro on a desk had no route to Files, Changes
+ * or Ship, which is not a tablet edge case; it is the tablet.
+ *
+ * So the two questions are separated, and neither is "is this a phone":
+ *
+ * - **Is there room for a rail beside the work?** Needs 236px. Below `md` it
+ *   becomes a drawer.
+ * - **Is there room for a panel as well?** Needs another 320px. Below `xl`
+ *   the three views it holds move into the pane, behind a switcher.
+ *
+ * The switcher is therefore not a mobile component. It is what Files, Changes
+ * and Ship look like when they cannot be a side panel, which is true at 400px
+ * and at 1200px alike — and one implementation serves both.
+ *
+ * ## Why these are hooks and not just classes
+ *
+ * Layout is CSS wherever it can be: `hidden md:flex` costs nothing, never
+ * disagrees with itself, and is right before the first frame. These exist for
+ * the cases that are not layout — a component tree that must not be mounted
+ * twice because it owns state, and behaviour that differs, like whether Enter
+ * sends a message.
+ *
+ * Prefer the class. Reach for these when rendering both would be wrong.
+ */
+
+import { useSyncExternalStore } from "react";
+
+/** Tailwind's own `md`. Below it, the rail is a drawer. */
+export const RAIL_AT = "(width >= 48rem)";
+
+/** Tailwind's own `xl`. Below it, the panel's views move into the pane. */
+export const PANEL_AT = "(width >= 80rem)";
+
+/**
+ * Subscribe once per query, not once per component.
+ *
+ * `useSyncExternalStore` calls `subscribe` with a fresh callback for every
+ * component that uses it, and a `MediaQueryList` per component would mean a
+ * listener per component. One list per query, with the watchers on it, is the
+ * same shape the panel and the notes stores already use.
+ */
+const lists = new Map<string, MediaQueryList>();
+
+function listFor(query: string): MediaQueryList | null {
+  if (typeof window === "undefined") return null;
+  let held = lists.get(query);
+  if (!held) {
+    held = window.matchMedia(query);
+    lists.set(query, held);
+  }
+  return held;
+}
+
+function useMatches(query: string, whenUnknown: boolean): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      const list = listFor(query);
+      if (!list) return () => {};
+      list.addEventListener("change", onChange);
+      return () => list.removeEventListener("change", onChange);
+    },
+    () => listFor(query)?.matches ?? whenUnknown,
+    // The static export is built with no window at all. Whatever is answered
+    // here is what the shipped HTML is laid out for, and the first paint in a
+    // browser corrects it — so the answer to give is the one that is least
+    // wrong to look at for a frame, which is the desk.
+    () => whenUnknown,
+  );
+}
+
+/** Room for the rail beside the work. False on a phone. */
+export function useHasRail(): boolean {
+  return useMatches(RAIL_AT, true);
+}
+
+/** Room for the side panel as well. False on a phone and on most tablets. */
+export function useHasPanel(): boolean {
+  return useMatches(PANEL_AT, true);
+}

--- a/web/src/workspace/overlay.ts
+++ b/web/src/workspace/overlay.ts
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * A document pushed over a workspace, on a screen with one column.
+ *
+ * A desk opens a file, a diff or a preview as a **tab**, beside the
+ * conversation that produced it — which is the whole reason the review panel
+ * stopped being a modal. None of that survives a single column: there is no
+ * beside, a tab strip of six things is unreadable at 375px, and closing a tab
+ * leaves you on whichever neighbour `without()` picks rather than on the list
+ * you opened it from.
+ *
+ * So below `xl` the same three things are one screen pushed on top, with a `‹`
+ * that returns to exactly where it came from. It is a stack one deep, because
+ * nothing here opens anything else.
+ *
+ * ## Why this hangs off `useOpen`
+ *
+ * Every caller — the tree, the changes list, the ship panel — says
+ * `open.diff(path)` and should not have to care which of the two it gets.
+ * `useOpen` is the one place that already exists to answer "open this thing",
+ * so it is where the fork belongs. Nothing else changes.
+ *
+ * Not persisted, and cleared when the workspace changes: a pushed document is
+ * where somebody is right now, not where they live.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export type Overlay =
+  | { kind: "file"; path: string }
+  | { kind: "diff"; path: string }
+  | { kind: "preview"; port: number };
+
+let held: Overlay | null = null;
+const watching = new Set<() => void>();
+
+function tell() {
+  for (const watcher of watching) watcher();
+}
+
+function listen(onChange: () => void) {
+  watching.add(onChange);
+  return () => {
+    watching.delete(onChange);
+  };
+}
+
+export function showOverlay(next: Overlay) {
+  held = next;
+  tell();
+}
+
+export function closeOverlay() {
+  if (!held) return;
+  held = null;
+  tell();
+}
+
+export function useOverlay() {
+  const now = useSyncExternalStore(
+    listen,
+    () => held,
+    () => null,
+  );
+  return {
+    overlay: now,
+    // Wrapped rather than passed through: these read the module and close over
+    // nothing, so the identity is stable either way — and the lint rule that
+    // insists on an inline function is right that a bare reference here is
+    // impossible to check.
+    show: useCallback((next: Overlay) => showOverlay(next), []),
+    close: useCallback(() => closeOverlay(), []),
+  };
+}

--- a/web/src/workspace/screen.ts
+++ b/web/src/workspace/screen.ts
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Which of the four things a workspace is showing, when it can only show one.
+ *
+ * Above `xl` this does not exist: the conversation is in the pane and Files,
+ * Changes and Ship are in the panel beside it, all visible at once. Below it
+ * there is one column, so they take turns, and this is whose turn it is.
+ *
+ * ## Why it is not `usePanel`
+ *
+ * The panel store answers a neighbouring question — which of its three views
+ * is forward, and whether it is collapsed — and it would have taken a fourth
+ * value. It is the wrong place: `panel.view` is remembered across sessions and
+ * across reloads because a side panel somebody set to Ship should still be on
+ * Ship tomorrow, and the answer to "what am I looking at in this workspace
+ * right now" should not be. Arriving at a workspace from a notification and
+ * landing on a file tree because that is where you were last week is not
+ * continuity, it is the app losing your place.
+ *
+ * So this resets to the conversation, per session, and is never written down.
+ *
+ * ## Why a module store rather than a context
+ *
+ * Same reason as the panel's: the header's switcher, the `⋯` menu and the
+ * Changes view's own "Review & ship" button all move it, and they are three
+ * levels apart in the tree. Threading a callback through would mean every
+ * component in between carrying a prop it has no use for.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export type Screen = "chat" | "files" | "changes" | "ship";
+
+/**
+ * The three in the switcher, in the order a phone wants them.
+ *
+ * Files is not here. It is in the `⋯` menu, because the two errands somebody
+ * opens this on a phone for are answering an agent and shipping what it wrote
+ * — and browsing a directory tree is neither.
+ */
+export const SCREENS: { id: Screen; label: string }[] = [
+  { id: "chat", label: "Chat" },
+  { id: "changes", label: "Diff" },
+  { id: "ship", label: "Ship" },
+];
+
+let screen: Screen = "chat";
+const watching = new Set<() => void>();
+
+function tell() {
+  for (const watcher of watching) watcher();
+}
+
+function listen(onChange: () => void) {
+  watching.add(onChange);
+  return () => {
+    watching.delete(onChange);
+  };
+}
+
+export function useScreen() {
+  const now = useSyncExternalStore(
+    listen,
+    () => screen,
+    () => "chat" as Screen,
+  );
+
+  const show = useCallback((next: Screen) => {
+    if (screen === next) return;
+    screen = next;
+    tell();
+  }, []);
+
+  return { screen: now, show };
+}
+
+/**
+ * Back to the conversation.
+ *
+ * Called when the workspace changes, so a new one opens on its agent rather
+ * than on whichever view the last one was left on. Outside React because the
+ * caller is an effect that already has the session id and no reason to
+ * subscribe to this.
+ */
+export function resetScreen() {
+  if (screen === "chat") return;
+  screen = "chat";
+  tell();
+}

--- a/web/src/workspace/tabs.tsx
+++ b/web/src/workspace/tabs.tsx
@@ -39,6 +39,9 @@ import {
   type ReactNode,
 } from "react";
 
+import { useHasPanel } from "./layout";
+import { showOverlay } from "./overlay";
+
 /** Which half of a split a tab is in. There are at most two. */
 export type PaneIndex = 0 | 1;
 
@@ -411,19 +414,42 @@ export function paneTabs(set: TabSet | null, pane: PaneIndex): Tab[] {
   return set.tabs.filter((t) => (set.pane[t.id] ?? 0) === pane);
 }
 
-/** Convenience for the many places that just want to open a thing. */
+/**
+ * Convenience for the many places that just want to open a thing.
+ *
+ * ## Two answers, one call
+ *
+ * A file, a diff and a preview are tabs on a desk and pushed screens below
+ * `xl` — see `overlay.ts` for why one column cannot use tabs. The fork is here
+ * rather than at each of the dozen call sites, so the tree, the changes list
+ * and the ship panel all say `open.diff(path)` and none of them knows or cares
+ * which layout it is in.
+ *
+ * `beside` is a request about *position* in a split, and a screen with one
+ * column has no other half to put anything in, so it is ignored there.
+ *
+ * A terminal is the exception and stays a tab either way: it is not offered
+ * below `xl` at all, because an xterm with no Esc, no Tab and no Ctrl is not a
+ * terminal.
+ */
 export function useOpen() {
   const { open, set } = useTabs();
+  const pushes = !useHasPanel();
+
   return {
     file: useCallback(
       (path: string, beside?: boolean) =>
-        open({ id: addressOf.file(path), kind: "file", path }, beside),
-      [open],
+        pushes
+          ? showOverlay({ kind: "file", path })
+          : open({ id: addressOf.file(path), kind: "file", path }, beside),
+      [open, pushes],
     ),
     diff: useCallback(
       (path: string, beside?: boolean) =>
-        open({ id: addressOf.diff(path), kind: "diff", path }, beside),
-      [open],
+        pushes
+          ? showOverlay({ kind: "diff", path })
+          : open({ id: addressOf.diff(path), kind: "diff", path }, beside),
+      [open, pushes],
     ),
     terminal: useCallback(() => {
       const n = set ? nextTerminal(set) : 1;
@@ -431,8 +457,10 @@ export function useOpen() {
     }, [open, set]),
     preview: useCallback(
       (port: number, beside?: boolean) =>
-        open({ id: addressOf.preview(port), kind: "preview", port }, beside),
-      [open],
+        pushes
+          ? showOverlay({ kind: "preview", port })
+          : open({ id: addressOf.preview(port), kind: "preview", port }, beside),
+      [open, pushes],
     ),
   };
 }

--- a/web/src/workspace/touch.ts
+++ b/web/src/workspace/touch.ts
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * The half of "stop it zooming" that CSS cannot do.
+ *
+ * Three layers are needed and none of them is sufficient alone:
+ *
+ * 1. `maximumScale` / `userScalable` in the viewport export — honoured by
+ *    Chrome and Firefox, and by Safari for everything except pinch.
+ * 2. `touch-action: pan-x pan-y` on the workbench (`.no-zoom`) — refuses the
+ *    pinch to the compositor, in every engine that reads it for zoom.
+ * 3. This — Safari's own gesture recognisers, which are not touch events and
+ *    which `touch-action` does not reach.
+ *
+ * Safari has ignored `user-scalable=no` for pinch since iOS 10, deliberately,
+ * because taking zoom away from a web page takes away an accessibility
+ * feature. That is a good rule and this is the case it is wrong about: the
+ * workbench is a scrolling, dragging, tapping surface where a pinch is a
+ * fumbled scroll, and the thing it was protecting — being able to make a diff
+ * bigger — is a control on the diff instead.
+ *
+ * Which is why this is a hook mounted on one subtree rather than a listener
+ * added once to the document. Tasks, Configuration, login and setup are
+ * documents and keep pinch.
+ *
+ * `gesturestart` and friends are WebKit-only and are not in the DOM lib, so
+ * they are subscribed by name. On every other browser nothing ever fires and
+ * this costs three listeners that are never called.
+ */
+
+import { useEffect, type RefObject } from "react";
+
+const GESTURES = ["gesturestart", "gesturechange", "gestureend"] as const;
+
+export function useNoZoom(on: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const el = on.current;
+    if (!el) return;
+
+    // `preventDefault` on the start alone is enough in current Safari, but a
+    // gesture that has already begun keeps sending changes — and a version
+    // that starts one anyway would otherwise scale the page while the finger
+    // moves and leave it there.
+    const refuse = (e: Event) => e.preventDefault();
+
+    // Not passive: the whole point is to cancel, and a passive listener may
+    // not. Browsers default some of these to passive when the target is the
+    // document, which is a second reason this is bound to an element.
+    for (const kind of GESTURES) el.addEventListener(kind, refuse, { passive: false });
+    return () => {
+      for (const kind of GESTURES) el.removeEventListener(kind, refuse);
+    };
+  }, [on]);
+}


### PR DESCRIPTION
Add responsive design and touch-friendly UI to support Firetower on mobile devices.

The interface now adapts to screen size: below 768px the sidebar becomes a drawer, tabs move to a card switcher, and modals become full-screen sheets. Below 1280px the switcher moves to the header. Viewport meta tags prevent unwanted zoom, `touch-action` blocks pinch-to-zoom on the workbench, and text inputs scale to 16px on phones so iOS doesn't zoom the page on focus. The static export serves both interface and API from a single port, making the app work through port forwards and proxies without hardcoded localhost references.

Closes #66