### PR TITLE
fix: apply permission mode change to running session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "ft-cli"
-version = "0.28.2"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "ft-core"
-version = "0.28.2"
+version = "0.30.0"
 dependencies = [
  "chrono",
  "serde",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "ft-proto"
-version = "0.28.2"
+version = "0.30.0"
 dependencies = [
  "chrono",
  "ft-core",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "ft-server"
-version = "0.28.2"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "ft-worker"
-version = "0.28.2"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ft-core/src/controls.rs
+++ b/crates/ft-core/src/controls.rs
@@ -249,19 +249,22 @@ pub fn for_agent(agent: crate::Agent, models: Vec<Choice>, efforts: Vec<Choice>)
     }
 }
 
-/// The slash command that puts one into force, for the agent that takes them
-/// that way.
+/// What to send to put one into force, for the agent that is told rather than
+/// asked.
 ///
-/// `None` for a setting this agent has no command for — Codex takes all of
-/// these as parameters on its next turn instead.
-pub fn command(agent: crate::Agent, kind: ControlKind, value: &str) -> Option<String> {
+/// `None` for a setting this agent has no way of being told about — Codex takes
+/// all of these as parameters on its next turn instead.
+///
+/// Not all one shape. `/model` and `/effort` say "for this session only" and
+/// mean it, so they are sent as input like anything else. The permission mode
+/// is not a slash command at all: see [`crate::turn::permission_mode`] for what
+/// happened to the session that was sent one.
+pub fn put(agent: crate::Agent, kind: ControlKind, value: &str) -> Option<serde_json::Value> {
     match agent {
         crate::Agent::ClaudeCode => match kind {
-            ControlKind::Model => Some(format!("/model {value}")),
-            // `/permissions` is not available headless; `/config` is, and
-            // takes it.
-            ControlKind::Mode => Some(format!("/config permissionMode={value}")),
-            ControlKind::Effort => Some(format!("/effort {value}")),
+            ControlKind::Model => Some(crate::turn::user_message(&format!("/model {value}"))),
+            ControlKind::Mode => Some(crate::turn::permission_mode(value)),
+            ControlKind::Effort => Some(crate::turn::user_message(&format!("/effort {value}"))),
             // It has no such thing.
             ControlKind::Sandbox => None,
         },
@@ -324,11 +327,61 @@ mod tests {
     /// is what it did before this existed.
     #[test]
     fn a_slash_command_is_only_ever_built_for_the_agent_that_reads_them() {
-        assert_eq!(
-            command(crate::Agent::ClaudeCode, ControlKind::Model, "opus[1m]").as_deref(),
-            Some("/model opus[1m]")
-        );
-        assert!(command(crate::Agent::Codex, ControlKind::Model, "gpt-5.6-sol").is_none());
-        assert!(command(crate::Agent::ClaudeCode, ControlKind::Sandbox, "workspace").is_none());
+        let chosen = put(crate::Agent::ClaudeCode, ControlKind::Model, "opus[1m]")
+            .expect("Claude Code is told which model to use");
+        assert_eq!(chosen["message"]["content"][0]["text"], "/model opus[1m]");
+
+        assert!(put(crate::Agent::Codex, ControlKind::Model, "gpt-5.6-sol").is_none());
+        assert!(put(crate::Agent::ClaudeCode, ControlKind::Sandbox, "workspace").is_none());
+    }
+
+    /// The bug this half exists for: picking "Never ask" mid-conversation
+    /// changed nothing at all.
+    ///
+    /// It was sent as `/config permissionMode=dontAsk`, which the agent answers
+    /// with "Set Default permission mode to dontAsk" — a default for the next
+    /// session. This one was given its mode as a command-line switch when
+    /// Firetower started it, kept it, and went on asking.
+    #[test]
+    fn the_permission_mode_is_changed_in_the_session_that_is_running() {
+        let chosen = put(crate::Agent::ClaudeCode, ControlKind::Mode, "dontAsk")
+            .expect("Claude Code is told when to ask");
+
+        assert_eq!(chosen["type"], "control_request");
+        assert_eq!(chosen["request"]["subtype"], "set_permission_mode");
+        assert_eq!(chosen["request"]["mode"], "dontAsk");
+
+        // Two of them must not collide: the agent matches its answers by id.
+        let again = put(crate::Agent::ClaudeCode, ControlKind::Mode, "dontAsk").unwrap();
+        assert_ne!(chosen["request_id"], again["request_id"]);
+
+        // And nothing about it is typed at the agent, which is what left the
+        // running session alone.
+        assert!(!chosen.to_string().contains("/config"));
+    }
+
+    /// Every mode offered is one the agent will take.
+    ///
+    /// Checked against the list it refuses an unknown one with: `acceptEdits,
+    /// auto, bypassPermissions, default, dontAsk, plan`. A picker that offers a
+    /// word the agent has never heard of is a control that silently does
+    /// nothing, which is the fault this whole file is about.
+    #[test]
+    fn every_mode_offered_is_one_the_agent_knows() {
+        const KNOWN: [&str; 6] = [
+            "acceptEdits",
+            "auto",
+            "bypassPermissions",
+            "default",
+            "dontAsk",
+            "plan",
+        ];
+        for choice in claude_modes() {
+            assert!(
+                KNOWN.contains(&choice.value.as_str()),
+                "{} is not a permission mode Claude Code takes",
+                choice.value
+            );
+        }
     }
 }

--- a/crates/ft-core/src/normalise.rs
+++ b/crates/ft-core/src/normalise.rs
@@ -312,8 +312,23 @@ impl ClaudeNormaliser {
                     });
                 }
             }
+            // The mode changed, which is the one thing this says that somebody
+            // can see. `init` restates it too, but only at the start of the
+            // next turn — long after they moved the picker and are watching to
+            // see whether it took. Nothing else in here is worth a card.
+            Some("status") => match str_at(v, "permissionMode") {
+                Some(mode) => out.push(TurnEvent::SessionConfigured {
+                    // Only what it said. A restatement fills in what it leaves
+                    // out, and this one is about the mode alone.
+                    model: String::new(),
+                    mode: mode.to_string(),
+                    tools: Vec::new(),
+                    commands: Vec::new(),
+                }),
+                None => out.push(raw(v)),
+            },
             // `task_updated` repeats what `task_notification` says with less in
-            // it, and `status`/`thinking_tokens` are telemetry.
+            // it, and the rest of `status`/`thinking_tokens` is telemetry.
             _ => out.push(raw(v)),
         }
     }
@@ -1135,6 +1150,36 @@ mod tests {
         ]);
         assert_eq!(usage.context_used, Some(40_012), "the main agent's request");
         assert_eq!(usage.context_window, Some(1_000_000));
+    }
+
+    /// A mode changed mid-turn has to be readable, or the picker sits on the
+    /// old value until the next turn starts and reads as not having worked.
+    ///
+    /// The line is what a real agent answered a `set_permission_mode` control
+    /// request with. It says the mode and nothing else, which is why a
+    /// restatement has to be allowed to leave the model out.
+    #[test]
+    fn a_mode_that_changed_says_so_without_forgetting_the_model() {
+        let mut reader = ClaudeNormaliser::new();
+        reader.push(
+            r#"{"type":"system","subtype":"init","model":"claude-opus-5[1m]","permissionMode":"auto","tools":["Bash"],"slash_commands":["model"]}"#,
+        );
+
+        let events = reader.push(
+            r#"{"type":"system","subtype":"status","status":null,"permissionMode":"dontAsk","uuid":"u1","session_id":"s1"}"#,
+        );
+        match events.as_slice() {
+            [TurnEvent::SessionConfigured { model, mode, .. }] => {
+                assert_eq!(mode, "dontAsk");
+                assert!(model.is_empty(), "it said nothing about the model");
+            }
+            other => panic!("expected the new mode, got {other:?}"),
+        }
+
+        // Anything else it carries is telemetry, and telemetry is not a card.
+        let quiet = reader
+            .push(r#"{"type":"system","subtype":"status","status":null,"thinking_tokens":10}"#);
+        assert!(matches!(quiet.as_slice(), [TurnEvent::Raw { .. }]));
     }
 
     #[test]

--- a/crates/ft-core/src/turn.rs
+++ b/crates/ft-core/src/turn.rs
@@ -545,6 +545,30 @@ fn denial(reason: Option<&str>) -> String {
     }
 }
 
+/// Change the permission mode of the session that is running.
+///
+/// A control request rather than something typed. Claude Code's stream-json
+/// input takes these beside ordinary messages and answers them out of band, so
+/// an agent in the middle of a turn takes one immediately rather than when it
+/// next reads its input — which is what somebody moving the picker means.
+///
+/// It is also the only thing that works. `/permissions` is not available
+/// headless; `/config permissionMode=…`, which is, answers "Set Default
+/// permission mode to …" and sets the default for the *next* session. This one
+/// was given its mode as a command-line switch and goes on asking, which is
+/// exactly what picking "Never ask" mid-conversation used to do: nothing.
+pub fn permission_mode(mode: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "control_request",
+        // The agent keeps these in a map and answers with the id it was given.
+        // Nothing here waits for the answer — the session says what mode it is
+        // in at the start of every turn, and that is what the picker shows —
+        // but two requests must not share an id.
+        "request_id": format!("firetower-{}", ulid::Ulid::new()),
+        "request": { "subtype": "set_permission_mode", "mode": mode },
+    })
+}
+
 pub fn user_message(text: &str) -> serde_json::Value {
     user_message_with(text, &[])
 }

--- a/crates/ft-server/src/api/sessions.rs
+++ b/crates/ft-server/src/api/sessions.rs
@@ -2704,13 +2704,21 @@ pub(super) async fn continue_with_account(
     kind: ft_core::Agent,
 ) -> Result<SessionId, ApiError> {
     let controls = state.fleet.controls(&session.id).await;
-    let mut claude_settings = None;
+    // The last thing said about each, and not the last thing said: a session
+    // that changed its mode mid-turn restates that alone, and taking the pair
+    // from it would carry an empty model over the one that is running.
+    let (mut claude_model, mut claude_mode) = (String::new(), String::new());
     if session.agent == ft_core::Agent::ClaudeCode {
         let mut reader = ft_core::normalise::Reader::for_agent(session.agent);
         for (_, line) in state.db.agent_lines_since(&session.id, 0).await? {
             for event in reader.push(&line) {
                 if let ft_core::TurnEvent::SessionConfigured { model, mode, .. } = event {
-                    claude_settings = Some((model, mode));
+                    if !model.is_empty() {
+                        claude_model = model;
+                    }
+                    if !mode.is_empty() {
+                        claude_mode = mode;
+                    }
                 }
             }
         }
@@ -2735,17 +2743,15 @@ pub(super) async fn continue_with_account(
                     .await?;
             }
         }
-        if let Some((model, mode)) = claude_settings {
-            for (kind, value) in [
-                (ft_core::controls::ControlKind::Model, model),
-                (ft_core::controls::ControlKind::Mode, mode),
-            ] {
-                if !value.is_empty() {
-                    state
-                        .fleet
-                        .choose(&session.host_id, &session.id, kind, &value)
-                        .await?;
-                }
+        for (kind, value) in [
+            (ft_core::controls::ControlKind::Model, claude_model),
+            (ft_core::controls::ControlKind::Mode, claude_mode),
+        ] {
+            if !value.is_empty() {
+                state
+                    .fleet
+                    .choose(&session.host_id, &session.id, kind, &value)
+                    .await?;
             }
         }
         state

--- a/crates/ft-server/src/db.rs
+++ b/crates/ft-server/src/db.rs
@@ -1560,6 +1560,62 @@ impl Db {
         }))
     }
 
+    /// Write down a choice somebody made about a session.
+    ///
+    /// Only for the settings nothing can be *told* — Codex takes its model,
+    /// effort, approval policy and fence as parameters on every turn, so the
+    /// choice has to be held and put on the next one. Held in the reader, it
+    /// lasted exactly as long as the agent process did: the reader is thrown
+    /// away when that ends, and the rebuilt one carried the defaults while the
+    /// picker went on showing what had been asked for.
+    ///
+    /// Claude Code is not written down here, and must not be. It is sent the
+    /// change, it answers with what it is now running, and that answer is what
+    /// the picker shows — a second record of the same thing could only disagree
+    /// with it.
+    pub async fn remember_control(
+        &self,
+        session_id: &SessionId,
+        kind: ft_core::controls::ControlKind,
+        value: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO session_controls (session_id, kind, value) VALUES ($1, $2, $3) \
+             ON CONFLICT (session_id, kind) DO UPDATE SET value = $3, chosen_at = now()",
+        )
+        .bind(session_id.as_str())
+        .bind(control_kind(kind))
+        .bind(value)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Everything somebody has chosen about a session, for a reader being built.
+    ///
+    /// A kind we no longer have is skipped rather than refused: a row written by
+    /// a version that offered something this one does not is not a reason to
+    /// open the session with nothing in force.
+    pub async fn chosen_controls(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Vec<(ft_core::controls::ControlKind, String)>> {
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT kind, value FROM session_controls WHERE session_id = $1")
+                .bind(session_id.as_str())
+                .fetch_all(&self.pool)
+                .await?;
+
+        Ok(rows
+            .into_iter()
+            .filter_map(|(kind, value)| {
+                serde_json::from_str(&format!("\"{kind}\""))
+                    .ok()
+                    .map(|kind| (kind, value))
+            })
+            .collect())
+    }
+
     /// Say where a session has got to, from what its agent said.
     ///
     /// The only writer of this field for an agent that speaks a protocol —
@@ -1902,6 +1958,15 @@ fn session_from_row(r: sqlx::postgres::PgRow) -> Result<Session> {
         created_at: r.get("created_at"),
         updated_at: r.get("updated_at"),
     })
+}
+
+/// Which picker a stored choice belongs to, spelled the way it goes over the
+/// wire — so a row and a request use one word for one thing.
+fn control_kind(kind: ft_core::controls::ControlKind) -> String {
+    serde_json::to_value(kind)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default()
 }
 
 /// A connection string without its password, for a message someone will paste.
@@ -2483,6 +2548,66 @@ mod tests {
         assert_eq!(session.repo, None);
         assert_eq!(session.branch, None);
         assert_eq!(session.base, None);
+    }
+
+    /// A choice is the person's, so it is kept against the session and not
+    /// against whatever happens to be reading its lines at the time.
+    #[tokio::test]
+    async fn a_choice_is_kept_until_it_is_changed() {
+        use ft_core::controls::ControlKind as K;
+
+        let (db, owner) = db_with_user().await;
+        let host = db.ensure_host("localhost", Compute::Local).await.unwrap();
+        let id = SessionId::new();
+        db.insert_session(
+            &id,
+            &host.id,
+            &owner,
+            None,
+            "A Codex session",
+            "go",
+            None,
+            None,
+            "Codex",
+            WorkspaceSize::Medium,
+            ft_core::Share::Equal,
+            &ft_core::Step::plan(false, false),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(db.chosen_controls(&id).await.unwrap().is_empty());
+
+        db.remember_control(&id, K::Mode, "never").await.unwrap();
+        db.remember_control(&id, K::Model, "gpt-5.6-sol")
+            .await
+            .unwrap();
+        // Changing one's mind replaces the choice rather than adding a second.
+        db.remember_control(&id, K::Mode, "untrusted")
+            .await
+            .unwrap();
+
+        let mut chosen = db.chosen_controls(&id).await.unwrap();
+        chosen.sort_by(|a, b| a.1.cmp(&b.1));
+        assert_eq!(
+            chosen,
+            vec![
+                (K::Model, "gpt-5.6-sol".to_string()),
+                (K::Mode, "untrusted".to_string()),
+            ]
+        );
+
+        // A row from a version that offered something this one does not is
+        // skipped, not fatal: the session still opens with the rest in force.
+        sqlx::query("INSERT INTO session_controls (session_id, kind, value) VALUES ($1, $2, $3)")
+            .bind(id.as_str())
+            .bind("telepathy")
+            .bind("on")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(db.chosen_controls(&id).await.unwrap().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/ft-server/src/fleet.rs
+++ b/crates/ft-server/src/fleet.rs
@@ -232,11 +232,11 @@ impl Progress {
     ) -> Result<Option<serde_json::Value>> {
         use ft_core::controls::ControlKind as K;
 
-        // The agent that reads slash commands out of its own input. Nothing to
-        // remember: it answers with a sentence saying what it did, and that is
-        // what the picker then shows.
-        if let Some(text) = ft_core::controls::command(self.agent, kind, value) {
-            return Ok(Some(ft_core::turn::user_message(&text)));
+        // The agent that is told. Nothing to remember: it says what it is
+        // running at the start of every turn, and that is what the picker then
+        // shows.
+        if let Some(message) = ft_core::controls::put(self.agent, kind, value) {
+            return Ok(Some(message));
         }
         if self.agent != ft_core::Agent::Codex {
             anyhow::bail!("{} cannot be asked to change that", self.agent.label());
@@ -2517,9 +2517,9 @@ impl Fleet {
 
     /// Change one of them.
     ///
-    /// What that means is the agent's business: a slash command for the one
-    /// that reads them out of its own input, and a parameter on the next turn
-    /// for the one that does not. The browser knows neither.
+    /// What that means is the agent's business: something sent down the pipe
+    /// for the one that is told, and a parameter on the next turn for the one
+    /// that is not. The browser knows neither.
     pub async fn choose(
         &self,
         host_id: &HostId,
@@ -3317,6 +3317,45 @@ mod progress_tests {
             first["id"], second["id"],
             "two questions cannot share one id, or an answer names both"
         );
+    }
+
+    /// The issue: changing when the agent asks, mid-conversation, did nothing.
+    ///
+    /// Both halves of it, because the two agents are told in different ways and
+    /// only one of them was wrong. Claude Code is sent a control request, which
+    /// it takes in the middle of a turn — it used to be typed at, and what was
+    /// typed set a default the running session never read. Codex is sent
+    /// nothing, and carries the choice on the next turn instead.
+    #[test]
+    fn changing_when_the_agent_asks_reaches_the_session_that_is_running() {
+        use ft_core::controls::ControlKind as K;
+
+        let mut claude = Progress::for_agent(ft_core::Agent::ClaudeCode, String::new());
+        let told = claude
+            .choose(K::Mode, "dontAsk")
+            .unwrap()
+            .expect("Claude Code is told, and told now");
+        assert_eq!(told["type"], "control_request");
+        assert_eq!(told["request"]["mode"], "dontAsk");
+
+        let mut codex = Progress::for_agent(ft_core::Agent::Codex, String::new());
+        codex.read(r#"{"id":2,"result":{"thread":{"id":"th_9"},"model":"gpt-5.6-sol","approvalPolicy":"on-request"}}"#);
+        assert!(
+            codex.choose(K::Mode, "never").unwrap().is_none(),
+            "nothing to send: it rides on the next turn"
+        );
+        assert_eq!(
+            codex
+                .controls()
+                .iter()
+                .find(|c| c.kind == K::Mode)
+                .and_then(|c| c.current.as_deref()),
+            Some("never"),
+            "and the picker shows what was chosen, not what the thread opened with"
+        );
+
+        let next = codex.turn("ok, you can continue", &[]).unwrap();
+        assert_eq!(next["params"]["approvalPolicy"], "never");
     }
 }
 

--- a/crates/ft-server/src/fleet.rs
+++ b/crates/ft-server/src/fleet.rs
@@ -225,19 +225,42 @@ impl Progress {
     }
 
     /// Put a choice into force, and say how.
+    ///
+    /// `None` means there was nothing to send and it was remembered instead —
+    /// which is also the signal to write it down, because this object does not
+    /// outlive the agent process it is reading.
     fn choose(
         &mut self,
         kind: ft_core::controls::ControlKind,
         value: &str,
     ) -> Result<Option<serde_json::Value>> {
-        use ft_core::controls::ControlKind as K;
-
         // The agent that is told. Nothing to remember: it says what it is
         // running at the start of every turn, and that is what the picker then
         // shows.
         if let Some(message) = ft_core::controls::put(self.agent, kind, value) {
             return Ok(Some(message));
         }
+
+        self.remember(kind, value)?;
+
+        // Nothing to send. It rides on the next turn, because there is no
+        // request that changes a thread's settings on its own.
+        Ok(None)
+    }
+
+    /// Hold a choice for the turns to come, without deciding anything about it.
+    ///
+    /// Both the moment somebody makes one and the moment a reader is rebuilt
+    /// and reads back what they chose before — the second is why the first
+    /// stopped being enough. A reader is thrown away when the agent process
+    /// ends, and a session whose agent is restarted — by an upgrade, by
+    /// somebody typing into one that had gone, by an account switch — used to
+    /// come back on the defaults with the picker still showing the choice.
+    fn remember(&mut self, kind: ft_core::controls::ControlKind, value: &str) -> Result<()> {
+        use ft_core::controls::ControlKind as K;
+
+        // The only agent with anything to hold. For the other, what is in force
+        // is what it last said it was running.
         if self.agent != ft_core::Agent::Codex {
             anyhow::bail!("{} cannot be asked to change that", self.agent.label());
         }
@@ -253,10 +276,7 @@ impl Progress {
                 )
             }
         }
-
-        // Nothing to send. It rides on the next turn, because there is no
-        // request that changes a thread's settings on its own.
-        Ok(None)
+        Ok(())
     }
 
     /// What this line means for the session, if anything.
@@ -2538,9 +2558,15 @@ impl Fleet {
         };
 
         // Nothing to send is an ordinary outcome, not a failure: it has been
-        // remembered and rides on the next turn.
+        // remembered and rides on the next turn. Written down as well as held,
+        // because what is holding it is a reader for one agent process and the
+        // choice has to outlive that — see `Db::remember_control`.
         let Some(message) = message else {
-            return Ok(());
+            return self
+                .db
+                .remember_control(session_id, kind, value)
+                .await
+                .with_context(|| format!("writing down {kind:?} for {session_id}"));
         };
 
         self.send(
@@ -2714,6 +2740,24 @@ impl Fleet {
         }
         if opened {
             progress.opening_prompt = None;
+        }
+
+        // And what somebody chose, which is not in the lines: it was never said
+        // to the agent, because this is the agent that takes it as a parameter
+        // on the next turn. Applied after the replay so that a choice wins over
+        // whatever the conversation was opened with.
+        for (kind, value) in self
+            .db
+            .chosen_controls(session_id)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(session = %session_id, "reading back what was chosen: {e:#}");
+                Vec::new()
+            })
+        {
+            if let Err(e) = progress.remember(kind, &value) {
+                tracing::warn!(session = %session_id, "{value} is no longer a choice: {e:#}");
+            }
         }
 
         self.progress
@@ -3504,6 +3548,82 @@ mod tests {
         fleet.supervise(host.clone(), Arc::new(Never)).await;
         assert!(fleet.try_now(&host).await);
         fleet.stop_supervising(&host).await;
+    }
+
+    /// The other half of the issue: a choice that only the reader knew about.
+    ///
+    /// Codex is not told when to ask — it is given the answer as a parameter on
+    /// every turn, and Firetower holds it in the object reading that session's
+    /// lines. That object is thrown away when the agent process ends, and an
+    /// agent ends often: an upgrade recreates every container, typing into a
+    /// session whose agent has gone restarts it, an account switch relaunches
+    /// it. What came back opened a new conversation on `on-request` and asked
+    /// about everything again, while the picker still said "Never ask".
+    #[tokio::test]
+    async fn what_somebody_chose_outlives_the_agent_they_chose_it_for() {
+        use ft_core::controls::ControlKind as K;
+
+        let (db, owner) = Db::open_for_test_owned().await.unwrap();
+        let host = db
+            .ensure_host("fire-01", ft_core::Compute::Local)
+            .await
+            .unwrap();
+        let session = SessionId::new();
+        db.insert_session(
+            &session,
+            &host.id,
+            &owner,
+            None,
+            "A Codex session",
+            "go",
+            None,
+            None,
+            "Codex",
+            ft_core::WorkspaceSize::Medium,
+            ft_core::Share::Equal,
+            &ft_core::Step::plan(false, false),
+            None,
+        )
+        .await
+        .unwrap();
+        let fleet = Fleet::new(db);
+
+        // Nothing goes to the host: there is no request that changes a thread's
+        // settings, so this is remembered for the next turn.
+        fleet
+            .choose(&host.id, &session, K::Mode, "never")
+            .await
+            .unwrap();
+        fleet
+            .choose(&host.id, &session, K::Sandbox, "workspace")
+            .await
+            .unwrap();
+
+        // The agent ends. Its reader goes with it — see `AgentClosed`.
+        fleet.progress.write().await.remove(session.as_str());
+
+        // And the next line from whatever replaced it builds a new one.
+        fleet.ensure_reader(&session).await;
+        let current = |controls: &[ft_core::controls::Control], kind| {
+            controls
+                .iter()
+                .find(|c| c.kind == kind)
+                .and_then(|c| c.current.clone())
+        };
+        let controls = fleet.controls(&session).await;
+        assert_eq!(current(&controls, K::Mode).as_deref(), Some("never"));
+        assert_eq!(current(&controls, K::Sandbox).as_deref(), Some("workspace"));
+
+        // Not just shown — carried. The new conversation opened on whatever
+        // `thread/start` says, and this is what puts it right.
+        let mut readers = fleet.progress.write().await;
+        let progress = readers.get_mut(session.as_str()).unwrap();
+        progress.read(
+            r#"{"id":2,"result":{"thread":{"id":"th_new"},"model":"gpt-5.6-sol","approvalPolicy":"on-request"}}"#,
+        );
+        let turn = progress.turn("ok, you can continue", &[]).unwrap();
+        assert_eq!(turn["params"]["approvalPolicy"], "never");
+        assert_eq!(turn["params"]["sandboxPolicy"]["networkAccess"], false);
     }
 }
 

--- a/migrations/server/20260911090000_session_controls.sql
+++ b/migrations/server/20260911090000_session_controls.sql
@@ -1,0 +1,19 @@
+-- What somebody chose for a session, for the agent that is not told.
+--
+-- Codex takes its model, effort, approval policy and sandbox as parameters on
+-- every turn rather than as anything it can be sent between them, so the choice
+-- has to be held somewhere and put on the next turn. It was held in the control
+-- plane's memory, beside the reader for that session's lines — and that reader
+-- is thrown away and rebuilt whenever the agent process ends. An upgrade, a
+-- restart, an account switch, a session picked up after its agent had gone: the
+-- new conversation opened on the defaults and every turn after it carried them,
+-- while the picker showed what had been asked for.
+--
+-- A choice is a person's, not a process's, so it lives with the session.
+create table session_controls (
+    session_id  text not null references sessions(id) on delete cascade,
+    kind        text not null,
+    value       text not null,
+    chosen_at   timestamptz not null default now(),
+    primary key (session_id, kind)
+);

--- a/web/src/api/conversation.ts
+++ b/web/src/api/conversation.ts
@@ -214,10 +214,12 @@ export function apply(state: Conversation, event: ConversationEvent): Conversati
   switch (event.type) {
     case "SessionConfigured":
       // Sent again at the start of every turn, so this must not reset
-      // anything — it is a restatement, not a new session.
+      // anything — it is a restatement, not a new session. And one that says
+      // only what changed — the mode, the moment somebody changed it — must
+      // not blank out the rest.
       return {
         ...state,
-        model: event.model,
+        model: event.model || state.model,
         mode: event.mode || state.mode,
         commands: event.commands.length ? event.commands : state.commands,
         lastLine,


### PR DESCRIPTION
When a user changed the "Ask" permission setting mid-conversation, the change was not reflected in the running session. For Claude Code, `/config permissionMode=…` was being sent as a slash command, which only sets a default for the next session — the running one kept its launch-time mode from the command-line switch. For Codex, the choice was held only in the reader's memory, which gets discarded and rebuilt whenever the agent process restarts (upgrades, account switches, session reconnects), causing the picker to show the old value while the new conversation opened on the defaults.

This fixes both: Claude Code now receives a `set_permission_mode` control request that changes the running session immediately; Codex choices are persisted to a `session_controls` table and read back when a reader is rebuilt. The normalizer now also recognizes mode changes in the `status` system event and surfaces them so the picker updates without waiting for the next turn.

Closes #73