### PR TITLE
fix(host-execution): reach workers again

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -10,7 +10,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.31.0"
+    "version": "0.32.0"
   },
   "paths": {
     "/api/v1/agent-accounts": {
@@ -6876,13 +6876,13 @@
       "Installed": {
         "type": "object",
         "description": "What answered after a worker was put there.",
-        "required": [
-          "version"
-        ],
         "properties": {
           "version": {
-            "type": "string",
-            "description": "What `firetower-worker --version` said on the machine."
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What `firetower-worker --version` said on the machine.\n\nAbsent when the copy succeeded and the probe did not answer. The\ninstall still happened; the supervisor's next connection is the verdict."
           }
         }
       },

--- a/api/updater.json
+++ b/api/updater.json
@@ -10,7 +10,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.30.1"
+    "version": "0.32.0"
   },
   "paths": {
     "/v1/deploy": {

--- a/crates/ft-cli/src/main.rs
+++ b/crates/ft-cli/src/main.rs
@@ -12,6 +12,12 @@ use std::path::PathBuf;
 #[command(
     name = "firetower",
     version,
+    // So `firetower worker --version` answers. A machine Firetower installs
+    // onto gets this binary under a wrapper that turns `firetower-worker
+    // --version` into exactly that, and clap keeps `--version` on the root
+    // command unless told otherwise — so the install's own health check failed
+    // on a worker that had copied across perfectly well.
+    propagate_version = true,
     about = "Run coding agents on your own servers.",
     long_about = None,
 )]

--- a/crates/ft-server/src/api/hosts.rs
+++ b/crates/ft-server/src/api/hosts.rs
@@ -440,7 +440,10 @@ async fn seen(state: &AppState, mut host: Host) -> Host {
 #[serde(rename_all = "camelCase")]
 pub struct Installed {
     /// What `firetower-worker --version` said on the machine.
-    pub version: String,
+    ///
+    /// Absent when the copy succeeded and the probe did not answer. The
+    /// install still happened; the supervisor's next connection is the verdict.
+    pub version: Option<String>,
 }
 
 /// Put a worker on this machine.

--- a/crates/ft-server/src/diagnose.rs
+++ b/crates/ft-server/src/diagnose.rs
@@ -5,6 +5,7 @@
 //! to stderr before the stream closed. Each case below has a different fix, and
 //! a closed stream on its own distinguishes none of them.
 
+use crate::transport::WORKER_BINARY;
 use ft_core::{Cause, Compute, Diagnosis};
 
 /// What a failed connection means, given what the far end said.
@@ -56,6 +57,19 @@ pub fn from_output(
         Diagnosis::new(
             Cause::DockerMissing,
             "Docker isn't installed on that machine.",
+        )
+    } else if said.contains("oci runtime exec failed") && !said.contains(WORKER_BINARY) {
+        // The runtime was asked to exec something that is not the worker at
+        // all. That is ours to fix, not the image's — a `PATH=…` word ahead of
+        // the program name once got read as a program *called* `PATH=…`, and
+        // every container-mode host was told to pull a new image over it.
+        Diagnosis::new(
+            Cause::Unknown,
+            format!(
+                "Firetower asked {} to run the wrong thing, and the container refused it. \
+                 This is a bug in Firetower, not in that machine.",
+                container(compute)
+            ),
         )
     } else if said.contains("firetower-worker: command not found")
         || said.contains("firetower-worker: not found")
@@ -227,6 +241,49 @@ mod tests {
 
     fn in_container() -> Compute {
         server_with(Some("firetower-worker"))
+    }
+
+    fn code(n: i32) -> Option<std::process::ExitStatus> {
+        use std::os::unix::process::ExitStatusExt;
+        Some(std::process::ExitStatus::from_raw(n << 8))
+    }
+
+    /// The one that sent every container-mode host to `docker compose pull`
+    /// over a bug in the argv Firetower assembled.
+    #[test]
+    fn a_runtime_asked_to_exec_the_wrong_thing_blames_firetower() {
+        let said = vec![
+            "OCI runtime exec failed: exec failed: unable to start container process: \
+             exec: \"PATH=/root/.firetower/worker/bin:/usr/bin\": \
+             stat PATH=/root/.firetower/worker/bin:/usr/bin: no such file or directory: unknown"
+                .to_string(),
+        ];
+        let told = from_output(&said, code(126), &in_container());
+        assert!(
+            told.summary.contains("bug in Firetower"),
+            "{}",
+            told.summary
+        );
+        assert!(
+            told.remedy.is_none(),
+            "nothing on that machine is going to fix it: {told:?}"
+        );
+    }
+
+    /// A container that really is running the wrong image still says so.
+    #[test]
+    fn a_runtime_that_cannot_find_the_worker_still_blames_the_image() {
+        let said = vec![
+            "OCI runtime exec failed: exec failed: unable to start container process: \
+             exec: \"firetower-worker\": executable file not found in $PATH: unknown"
+                .to_string(),
+        ];
+        let told = from_output(&said, code(126), &in_container());
+        assert!(
+            told.summary.contains("isn't a Firetower worker"),
+            "{}",
+            told.summary
+        );
     }
 
     fn read(lines: &[&str], compute: &Compute) -> Diagnosis {

--- a/crates/ft-server/src/install.rs
+++ b/crates/ft-server/src/install.rs
@@ -12,6 +12,11 @@
 //! `~/.firetower/worker/bin` — which the worker already owns, and which
 //! [`crate::transport::worker_command`] puts last on PATH so an operator's own
 //! copy still wins.
+//!
+//! Not the small artifact `Dockerfile.worker` builds: the control-plane image
+//! carries one binary, so what goes down the wire is that binary under a
+//! two-line wrapper. Bigger than it needs to be, and the alternative is
+//! carrying a second worker build in an image that never runs it.
 
 use crate::transport::{SshTransport, INSTALLED_BIN, WORKER_BINARY};
 use anyhow::{Context, Result};
@@ -32,10 +37,12 @@ pub struct Source {
 
 /// The worker to send: the one built beside us, or failing that, ourselves.
 ///
-/// A release image carries both binaries, so the first branch is the usual one
-/// and the far end gets exactly the program it is asked for. The second is what
-/// makes this work for a control plane installed on its own — the binary
-/// running this code can do the worker's job, it is just spelled differently.
+/// A source checkout builds both binaries side by side, so the first branch is
+/// what anyone developing this hits. The release image carries only
+/// `firetower`, so the second is the one production takes — the binary running
+/// this code can do the worker's job, it is just spelled differently, and a
+/// wrapper is cheaper than a second worker build in an image that never runs
+/// it.
 pub fn source_from(exe: &Path) -> Result<Source> {
     let sibling = exe.with_file_name(WORKER_BINARY);
     if sibling.is_file() {
@@ -129,7 +136,12 @@ chmod 755 \"{INSTALLED_BIN}/{WORKER_BINARY}\"
 }
 
 /// Put the worker there, and say what version answered afterwards.
-pub async fn install(ssh: &SshTransport) -> Result<String> {
+///
+/// The version is `None` when the bytes landed and the probe did not answer.
+/// Those are two outcomes, and treating the second as a failed install threw
+/// away a worker that was sitting there working: the caller stopped short of
+/// waking the supervisor, so nothing tried the machine again.
+pub async fn install(ssh: &SshTransport) -> Result<Option<String>> {
     let uname = ssh
         .ask("uname -sm")
         .await
@@ -145,11 +157,16 @@ pub async fn install(ssh: &SshTransport) -> Result<String> {
         .await
         .context("sending the worker")?;
 
-    // Asked the way a connection will ask, so this fails here rather than at
-    // the next launch if the installed copy cannot answer.
-    ssh.ask(&format!("{} --version", crate::transport::worker_command()))
-        .await
-        .context("the worker was copied, but did not answer --version")
+    // Asked the way a connection will ask, so a probe and a session resolve to
+    // the same binary. Not fatal: the copy is what was requested, and the real
+    // verdict is the supervisor's next connection.
+    match ssh.ask(&crate::transport::worker_probe()).await {
+        Ok(version) => Ok(Some(version)),
+        Err(e) => {
+            tracing::warn!("the worker was copied, but did not answer --version: {e:#}");
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ft-server/src/transport.rs
+++ b/crates/ft-server/src/transport.rs
@@ -258,15 +258,64 @@ pub const WORKER_BINARY: &str = "firetower-worker";
 /// machine can resolve.
 pub const INSTALLED_BIN: &str = "$HOME/.firetower/worker/bin";
 
-/// The remote command, with the directory Firetower installs into on PATH.
+/// A worker command run through a POSIX shell, with the installed directory
+/// last on PATH.
 ///
-/// Prepended rather than replacing the name: a worker the operator installed —
-/// a package, a binary in `/usr/local/bin` — is the one they meant, and an
-/// installed copy is only there because nothing else answered. ssh joins its
-/// arguments and hands the string to the account's shell, which is what makes a
-/// `VAR=value` prefix work here at all.
-pub fn worker_command() -> String {
-    format!("PATH={INSTALLED_BIN}:$PATH {WORKER_BINARY}")
+/// Two things about this are deliberate.
+///
+/// **`sh -c` rather than a bare `VAR=value` prefix.** ssh joins its arguments
+/// and hands the string to the *account's login shell*, whatever that is. csh,
+/// tcsh and fish all reject `VAR=value cmd` outright and exit without running
+/// anything — which arrives back here as an exit status this cannot tell apart
+/// from a worker that was never installed. Naming `sh` makes the syntax
+/// somebody else's shell has to accept a syntax we chose.
+///
+/// **The installed directory goes last.** A worker the operator put on the
+/// machine — a package, a binary in `/usr/local/bin` — is the one they meant,
+/// and Firetower's copy is only there because nothing else answered. This is
+/// what `install.rs` and `docs/host-execution.md` have always said; the code
+/// prepended, so an install that had gone wrong shadowed a worker that worked.
+///
+/// The script is single-quoted, so `$PATH` and `$HOME` reach the inner `sh`
+/// unexpanded and are that machine's rather than anything resolved here. `$0`
+/// takes the word after the script, hence the repeated binary name — without
+/// it `sh` would swallow `--stdio` as its own name.
+fn through_sh(args: &str) -> String {
+    format!(
+        "sh -c 'PATH=\"$PATH:{INSTALLED_BIN}\" exec {WORKER_BINARY} \"$@\"' {WORKER_BINARY} {args}"
+    )
+}
+
+/// Single-quote a path for the remote shell.
+fn quoted(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', r"'\''"))
+}
+
+/// The command that starts a worker on the far end.
+///
+/// Inside a container there is no shell in front of it: `docker exec` takes a
+/// program and its arguments, so a `PATH=…` word ahead of the program name is
+/// read as a program *called* `PATH=…` and nothing runs. That is what broke
+/// every container-mode worker. A container's worker comes from its image
+/// anyway — [`crate::api::hosts::install_worker`] refuses to touch one — so
+/// there is nothing for the installed directory to add there.
+pub fn worker_command(containerised: bool, root: Option<&std::path::Path>) -> String {
+    let mut args = String::from("--stdio");
+    if let Some(root) = root {
+        args.push_str(&format!(" --root {}", quoted(root)));
+    }
+
+    if containerised {
+        format!("{WORKER_BINARY} {args}")
+    } else {
+        through_sh(&args)
+    }
+}
+
+/// What to ask a freshly installed worker, so a probe and a session resolve to
+/// the same binary.
+pub fn worker_probe() -> String {
+    through_sh("--version")
 }
 
 pub struct SshTransport {
@@ -526,11 +575,13 @@ impl Transport for SshTransport {
             ssh.arg("docker").arg("exec").arg("-i").arg(container);
         }
 
-        ssh.arg(worker_command()).arg("--stdio");
-
-        if let Some(root) = &self.root {
-            ssh.arg("--root").arg(root);
-        }
+        // One argument, because ssh joins them with spaces and hands the
+        // result to a shell anyway — and the quoting inside only survives if
+        // this side does not add its own.
+        ssh.arg(worker_command(
+            self.container.is_some(),
+            self.root.as_deref(),
+        ));
 
         let mut child = ssh
             .stdin(Stdio::piped())
@@ -776,19 +827,70 @@ mod tests {
     /// A worker Firetower installed is found without being on anybody's PATH,
     /// and a worker the operator installed still wins.
     #[test]
-    fn the_remote_command_looks_where_firetower_installs() {
-        let command = worker_command();
+    fn the_remote_command_looks_where_firetower_installs_last() {
+        let command = worker_command(false, None);
         assert!(
-            command.ends_with(&format!(" {WORKER_BINARY}")),
-            "the name asked for is unchanged: {command}"
+            command.contains(&format!("PATH=\"$PATH:{INSTALLED_BIN}\"")),
+            "appended, so an operator's own copy is the one that answers: {command}"
         );
         assert!(
-            command.starts_with(&format!("PATH={INSTALLED_BIN}:$PATH ")),
-            "installed last, so an operator's own copy is the one that answers: {command}"
+            !command.contains(&format!("PATH=\"{INSTALLED_BIN}")),
+            "never prepended — that shadows a worker somebody installed themselves: {command}"
         );
-        // Expanded by the account's shell, not by this process — a path
+        // Expanded by the shell on that machine, not by this process — a path
         // resolved here would be a path inside the control plane's container.
         assert!(command.contains("$HOME"), "{command}");
+    }
+
+    /// The account's login shell may be csh or fish, which reject
+    /// `VAR=value cmd` and exit without running anything.
+    #[test]
+    fn a_direct_host_is_asked_through_a_posix_shell() {
+        let command = worker_command(false, None);
+        assert!(command.starts_with("sh -c '"), "{command}");
+        // `$0` eats the word after the script, so the name has to be repeated
+        // or `--stdio` is swallowed as the shell's own name.
+        assert!(
+            command.ends_with(&format!("' {WORKER_BINARY} --stdio")),
+            "{command}"
+        );
+    }
+
+    /// `docker exec` takes a program, not a shell line: a `PATH=…` word in
+    /// front of the name is read as a program called `PATH=…`, and every
+    /// container-mode worker stopped answering.
+    #[test]
+    fn a_container_is_asked_for_the_program_and_nothing_else() {
+        let command = worker_command(true, None);
+        assert_eq!(command, format!("{WORKER_BINARY} --stdio"));
+        assert!(!command.contains("PATH="), "{command}");
+        assert!(!command.contains("sh -c"), "{command}");
+    }
+
+    /// The root the image uses, and any root with a space in it.
+    #[test]
+    fn a_root_is_quoted_for_the_shell_on_the_other_side() {
+        let command = worker_command(
+            true,
+            Some(std::path::Path::new("/var/lib/firetower/worker")),
+        );
+        assert!(
+            command.ends_with("--stdio --root '/var/lib/firetower/worker'"),
+            "{command}"
+        );
+
+        let spaced = worker_command(false, Some(std::path::Path::new("/mnt/big disk/worker")));
+        assert!(spaced.contains("--root '/mnt/big disk/worker'"), "{spaced}");
+    }
+
+    /// Whatever answers a probe is what will answer a session.
+    #[test]
+    fn the_probe_resolves_the_same_binary_a_session_would() {
+        let probe = worker_probe();
+        let session = worker_command(false, None);
+        let script = |s: &str| s[s.find('\'').unwrap()..s.rfind('\'').unwrap()].to_string();
+        assert_eq!(script(&probe), script(&session));
+        assert!(probe.ends_with("--version"), "{probe}");
     }
 
     /// Every one of these is a mistake someone makes once, and each has to

--- a/docs/host-execution.md
+++ b/docs/host-execution.md
@@ -17,20 +17,28 @@ any other.
 ## Add a machine
 
 Open Compute → **Add a machine**, or pick **+ Add a machine…** at the end of the
-machine list in the new workspace form. It asks for two things:
+machine list in the new workspace form. It asks for:
 
-1. **An SSH address** reachable from the control plane, in the form ssh takes:
-   `editor@192.0.2.10`, with `:2222` for a port that is not 22. Left off, the
-   account is whatever your SSH config says.
-2. **A name**, optionally. Left blank, the machine is called where it is.
+1. **An IP address or hostname** reachable from the control plane, with `:2222`
+   for a port that is not 22. A whole `editor@192.0.2.10` destination pasted
+   here comes apart on its own.
+2. **An SSH account**, optionally. Left blank, the account is whatever your SSH
+   config says.
+3. **A container name**, for when the machine is used in Container mode.
+   `firetower-worker` unless yours is called something else.
+4. **A name**, optionally. Left blank, the machine is called where it is.
+
+Both environments are created: the machine itself, and the container named
+above.
 
 Authorize Firetower's public SSH key on that account, or select a private key
 already available to the control plane. Choose **Add**; a machine that does not
 answer is still saved, with what it said and what to do about it.
 
-Both ways of running are then available on it. Firetower checks whichever you
-pick, when you pick it, and the environment behind it is created then — there is
-nothing to set up in advance and no separate setup step.
+Both ways of running are then available on it. New workspace opens on
+**Container** unless the machine only has a host environment. Firetower checks
+whichever you pick, when you pick it; a mode a machine has never run gets its
+environment made at that point, so there is no separate setup step.
 
 For the underlying VM on the same server, use its reachable IP or hostname.
 Entering `localhost` while the control plane is in Docker connects inside that
@@ -62,6 +70,12 @@ connection it already has, into `~/.firetower/worker/bin`. No sudo, nothing
 outside the account's home, and nothing touched that you installed yourself: the
 remote command puts that directory *last* on `PATH`, so a `firetower-worker` you
 put on the machine is still the one that answers.
+
+The worker is launched through `sh -c` rather than by name alone, so the `PATH`
+it is given does not depend on what the SSH account's login shell is — `csh` and
+`fish` reject the `VAR=value command` form outright. A container is sent the
+bare program name instead: `docker exec` takes a program and its arguments, not
+a shell line, and a container's worker comes from its image.
 
 This works when the machine is the same operating system and architecture as the
 control plane, which it checks with `uname -sm` before sending anything. When

--- a/web/components/AddCompute.tsx
+++ b/web/components/AddCompute.tsx
@@ -15,30 +15,34 @@ import { parseDestination } from "@/src/api/environments";
 /**
  * Adding a machine.
  *
- * ## What this stopped asking
+ * ## What it asks, and what it stopped asking
  *
- * It used to ask five questions: this server or a remote one, container or
- * directly on host, a name for the *environment*, an address, an account, and —
- * for a container — its name. Every one of those except the address was either
- * already answered on the form that opened this, or is not a question about a
- * machine at all:
+ * Three fields about the machine — where it is, who to connect as, and what to
+ * call the container when one is used — plus the key it has to be given.
  *
- * * **Container or host** is a mode, chosen per workspace, on the machine. Both
- *   are available on everything Firetower can reach.
- * * **This server or remote** was only ever about ssh-ing to the machine
+ * The address and the account were briefly one box taking `editor@10.0.4.7`.
+ * They are two things: an address is where, an account is who, and a form is
+ * clearer when it says so. The single box also quietly dropped the container
+ * name, which left no way to point Firetower at a container called anything
+ * other than `firetower-worker`. Pasting a whole destination into the address
+ * still works — `parseDestination` splits it and the server prefers a field
+ * somebody filled in over one it parsed.
+ *
+ * Two questions did go, and stay gone:
+ *
+ * * **Container or directly on host** is a mode, chosen per workspace, on the
+ *   machine. Both are available on everything Firetower can reach, so asking
+ *   here meant adding the same machine twice to get both.
+ * * **This server or a remote one** was only ever about ssh-ing to the machine
  *   Firetower is already on. It does not.
- * * **The account** belongs to the address. `Compute::Server` treats `user` as
- *   optional and defers to your ssh config when it is absent, so a second field
- *   could only disagree with the first — and `editor@10.0.4.7` is what people
- *   paste anyway.
- * * **The name** is what you call it, and if you call it nothing it is called
- *   where it is. The server fills it in from the address.
- *
- * What is left is one address, an optional name, and the key the machine has to
- * be given — which is the one part of this nothing here can do.
  */
+/** The container to look for, and the only one anybody has to type. */
+const DEFAULT_CONTAINER = "firetower-worker";
+
 export function AddCompute({ onClose }: { onClose: () => void }) {
   const [address, setAddress] = useState("");
+  const [user, setUser] = useState("");
+  const [container, setContainer] = useState(DEFAULT_CONTAINER);
   const [label, setLabel] = useState("");
   const [keyPath, setKeyPath] = useState("");
   const [ownKey, setOwnKey] = useState(false);
@@ -47,7 +51,10 @@ export function AddCompute({ onClose }: { onClose: () => void }) {
   const create = useCreateHost();
   const probe = useProbeHost();
   const busy = create.isPending || probe.isPending;
+  // Only so the form can show what it made of a pasted destination. The server
+  // parses the address itself and prefers the account field when it has one.
   const typed = parseDestination(address);
+  const account = user.trim() || typed.user || "";
   const ready = !!typed.host;
 
   const edit =
@@ -57,28 +64,47 @@ export function AddCompute({ onClose }: { onClose: () => void }) {
       setter(value);
     };
 
-  // One environment, reached directly on the machine. A container on it is the
-  // same connection with `docker exec` in front, and is made when somebody
-  // picks that mode — not here, on a form about where the machine is.
+  // The environment made here is the one reached directly on the machine. The
+  // container on it is the same connection with `docker exec` in front, and is
+  // made when somebody picks that mode — but the *name* to use has to be
+  // collected now, because nothing later asks for it.
   const body = () => ({
     name: label.trim() || undefined,
     compute: {
       type: "Server",
       host: address.trim(),
+      user: user.trim() || undefined,
       key: ownKey && keyPath.trim() ? { type: "File", path: keyPath.trim() } : { type: "Managed" },
     } as Compute,
   });
 
-  const save = () =>
-    create.mutate(
-      { data: body() },
-      {
-        onSuccess: async () => {
-          await cache.invalidateQueries({ queryKey: getListHostsQueryKey() });
-          onClose();
-        },
-      },
-    );
+  // Both environments, in one go.
+  //
+  // A machine is a place and the two ways of running on it are modes, so a
+  // machine that has just been added should have both — otherwise picking
+  // Container in New workspace has to invent one, and the name typed above
+  // would have nowhere to live. The container is created rather than probed:
+  // whether it is running is a question for the moment somebody picks it, and
+  // it is the one HostReadiness already answers.
+  const save = async () => {
+    await create.mutateAsync({ data: body() });
+    const named = container.trim();
+    if (named) {
+      const base = label.trim() || typed.host;
+      await create
+        .mutateAsync({
+          data: {
+            name: `${base} · container`,
+            compute: { ...body().compute, container: named } as Compute,
+          },
+        })
+        // A machine that is added and a second environment that is not is
+        // still a machine that is added. Picking Container makes one.
+        .catch(() => {});
+    }
+    await cache.invalidateQueries({ queryKey: getListHostsQueryKey() });
+    onClose();
+  };
 
   const add = () =>
     probe.mutate(
@@ -94,15 +120,40 @@ export function AddCompute({ onClose }: { onClose: () => void }) {
   return (
     <Modal title="Add a machine" onClose={onClose} wide>
       <Field
-        label="SSH address"
+        label="IP address or hostname"
         autoFocus
         value={address}
         onChange={edit(setAddress)}
-        placeholder="editor@192.0.2.10"
+        placeholder="192.0.2.10"
       >
-        Where it is, and who to connect as. <code className="font-mono">user@host</code>, with{" "}
-        <code className="font-mono">:2222</code> for a port that is not 22. Left off, the account is
-        whatever your ssh config says.
+        Reachable from Firetower. Add <code className="font-mono">:2222</code> for a port that is
+        not 22. A whole <code className="font-mono">user@host</code> destination can be pasted here
+        and it comes apart on its own.
+      </Field>
+
+      <Field
+        label="SSH account"
+        optional
+        value={user}
+        onChange={edit(setUser)}
+        placeholder={typed.user || "editor"}
+      >
+        Who to connect as. Directly on the host, the worker and its agents run as this account with
+        its permissions; for a container, it is the account that runs{" "}
+        <code className="font-mono">docker exec</code>. Left blank, it is whatever your ssh config
+        says.
+      </Field>
+
+      <Field
+        label="Container name"
+        optional
+        value={container}
+        onChange={edit(setContainer)}
+        placeholder={DEFAULT_CONTAINER}
+      >
+        Which container to run agents in, when this machine is used in Container mode. Leave it as{" "}
+        <code className="font-mono">{DEFAULT_CONTAINER}</code> unless yours is called something
+        else.
       </Field>
 
       <Field
@@ -120,12 +171,13 @@ export function AddCompute({ onClose }: { onClose: () => void }) {
         onOwnKey={setOwnKey}
         keyPath={keyPath}
         onKeyPath={edit(setKeyPath)}
-        user={typed.user ?? ""}
+        user={account}
       />
 
       <p className="mt-3 text-meta leading-[1.5] text-mute">
-        Both ways of running are then available on it — in a worker container, or on the machine
-        itself. Firetower checks whichever you pick, when you pick it, and says what is missing.
+        Both ways of running are then available on it — in the worker container named above, or on
+        the machine itself. Firetower checks whichever you pick, when you pick it, and says what is
+        missing.
       </p>
 
       {(create.error || probe.error) && (

--- a/web/components/WhereItRuns.tsx
+++ b/web/components/WhereItRuns.tsx
@@ -90,14 +90,12 @@ export function WhereItRuns({
   const onlyMode = local
     ? (machine?.hosts.map(executionOf).find(Boolean) ?? "container")
     : undefined;
-  const has = (mode: Execution) => (machine?.hosts ?? []).some((h) => executionOf(h) === mode);
-  // Landing on a machine lands on a mode it actually runs. Only choosing the
-  // other one asks for it to be made.
-  const execution =
-    onlyMode ??
-    (where.picked || has(where.execution)
-      ? where.execution
-      : (modesOn(machine)[0] ?? where.execution));
+  // Landing on a machine lands on Container unless that machine only runs on
+  // the host. Container is the answer for almost everybody — the agent gets the
+  // image's tools rather than whatever happens to be on someone's VM — and
+  // `modesOn` returned whichever environment the list happened to hold first,
+  // so which mode you landed on depended on row order.
+  const execution = onlyMode ?? (where.picked ? where.execution : defaultMode(machine));
 
   const here = (machine?.hosts ?? []).filter((h) => executionOf(h) === execution);
   const host = where.hostId
@@ -330,6 +328,18 @@ export function nameFor(hosts: Host[], address: string, execution: Execution): s
   }
 }
 
+/**
+ * The mode a machine opens on, before anybody picks.
+ *
+ * Container, unless the machine has a host environment and no container one.
+ * A machine with neither is new, and a new machine's first environment should
+ * be a container too.
+ */
+export function defaultMode(machine: Machine | undefined): Execution {
+  const modes = modesOn(machine);
+  return modes.length === 1 && modes[0] === "host" ? "host" : "container";
+}
+
 /** Which environment the form would actually use, for the caller's own checks. */
 export function resolve(hosts: Host[], where: Where): { machine?: Machine; host?: Host } {
   const all = machines(hosts);
@@ -337,9 +347,9 @@ export function resolve(hosts: Host[], where: Where): { machine?: Machine; host?
   const modes = modesOn(machine);
   const execution = isLocal(machine)
     ? (modes[0] ?? where.execution)
-    : where.picked || modes.includes(where.execution)
+    : where.picked
       ? where.execution
-      : (modes[0] ?? where.execution);
+      : defaultMode(machine);
   const here = (machine?.hosts ?? []).filter((h) => executionOf(h) === execution);
   return {
     machine,

--- a/web/components/where-it-runs.test.tsx
+++ b/web/components/where-it-runs.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { WhereItRuns, nameFor, type Where } from "./WhereItRuns";
+import { WhereItRuns, nameFor, defaultMode, type Where } from "./WhereItRuns";
 import { getHostReadinessQueryKey } from "@/src/api/generated/hosts/hosts";
 import type { AgentView, Host, Readiness } from "@/src/api/generated/model";
+import { machines } from "@/src/api/environments";
 
 const host = (id: string, compute: Host["compute"], extra: Partial<Host> = {}): Host => ({
   id,
@@ -177,5 +178,32 @@ describe("what an environment nobody names is called", () => {
     const existing = [host("c", ssh("worker", "10.0.4.7"), { name: "10.0.4.7 · container" })];
     expect(nameFor(existing, "10.0.4.7", "host")).toBe("10.0.4.7");
     expect(nameFor(existing, "10.0.4.7", "container")).toBe("10.0.4.7 · container 2");
+  });
+});
+
+describe("the mode a machine opens on", () => {
+  const machineWith = (...hosts: Host[]) => machines(hosts)[0];
+
+  it("is the container, because that is what almost everybody wants", () => {
+    expect(defaultMode(machineWith(host("a", ssh("firetower-worker"))))).toBe("container");
+  });
+
+  it("is still the container when the machine already has both", () => {
+    // It used to be whichever environment the list happened to hold first, so
+    // which mode you landed on depended on row order.
+    expect(defaultMode(machineWith(host("h", ssh()), host("c", ssh("firetower-worker"))))).toBe(
+      "container",
+    );
+    expect(defaultMode(machineWith(host("c", ssh("firetower-worker")), host("h", ssh())))).toBe(
+      "container",
+    );
+  });
+
+  it("is the host only on a machine that runs nothing else", () => {
+    expect(defaultMode(machineWith(host("h", ssh())))).toBe("host");
+  });
+
+  it("is the container on a machine with no environments at all", () => {
+    expect(defaultMode(undefined)).toBe("container");
   });
 });

--- a/web/src/api/generated/accounts/accounts.ts
+++ b/web/src/api/generated/accounts/accounts.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/accounts/accounts.zod.ts
+++ b/web/src/api/generated/accounts/accounts.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/agents/agents.ts
+++ b/web/src/api/generated/agents/agents.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/agents/agents.zod.ts
+++ b/web/src/api/generated/agents/agents.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/auth/auth.ts
+++ b/web/src/api/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/auth/auth.zod.ts
+++ b/web/src/api/generated/auth/auth.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/conversation/conversation.ts
+++ b/web/src/api/generated/conversation/conversation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/conversation/conversation.zod.ts
+++ b/web/src/api/generated/conversation/conversation.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/events/events.ts
+++ b/web/src/api/generated/events/events.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useQuery,

--- a/web/src/api/generated/events/events.zod.ts
+++ b/web/src/api/generated/events/events.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/hosts/hosts.ts
+++ b/web/src/api/generated/hosts/hosts.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/hosts/hosts.zod.ts
+++ b/web/src/api/generated/hosts/hosts.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 
@@ -446,7 +446,7 @@ export const InstallWorkerParams = zod.object({
 })
 
 export const InstallWorkerResponse = zod.object({
-  "version": zod.string().describe('What `firetower-worker --version` said on the machine.')
+  "version": zod.string().nullish().describe('What `firetower-worker --version` said on the machine.\n\nAbsent when the copy succeeded and the probe did not answer. The\ninstall still happened; the supervisor\'s next connection is the verdict.')
 }).describe('What answered after a worker was put there.')
 
 /**

--- a/web/src/api/generated/meta/meta.ts
+++ b/web/src/api/generated/meta/meta.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useQuery,

--- a/web/src/api/generated/meta/meta.zod.ts
+++ b/web/src/api/generated/meta/meta.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/model/accessEntry.ts
+++ b/web/src/api/generated/model/accessEntry.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/account.ts
+++ b/web/src/api/generated/model/account.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Limit } from './limit';
 

--- a/web/src/api/generated/model/agent.ts
+++ b/web/src/api/generated/model/agent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/agentMode.ts
+++ b/web/src/api/generated/model/agentMode.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/agentOnHost.ts
+++ b/web/src/api/generated/model/agentOnHost.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface AgentOnHost {

--- a/web/src/api/generated/model/agentPresence.ts
+++ b/web/src/api/generated/model/agentPresence.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 

--- a/web/src/api/generated/model/agentView.ts
+++ b/web/src/api/generated/model/agentView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 import type { AgentMode } from './agentMode';

--- a/web/src/api/generated/model/annotationSelection.ts
+++ b/web/src/api/generated/model/annotationSelection.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { AnnotationVersion } from './annotationVersion';
 

--- a/web/src/api/generated/model/annotationVersion.ts
+++ b/web/src/api/generated/model/annotationVersion.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface AnnotationVersion {

--- a/web/src/api/generated/model/answer.ts
+++ b/web/src/api/generated/model/answer.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Decision } from './decision';
 

--- a/web/src/api/generated/model/apiError.ts
+++ b/web/src/api/generated/model/apiError.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ErrorCode } from './errorCode';
 

--- a/web/src/api/generated/model/attached.ts
+++ b/web/src/api/generated/model/attached.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/attachment.ts
+++ b/web/src/api/generated/model/attachment.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/auth.ts
+++ b/web/src/api/generated/model/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/bootstrap.ts
+++ b/web/src/api/generated/model/bootstrap.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/branches.ts
+++ b/web/src/api/generated/model/branches.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Branches {

--- a/web/src/api/generated/model/capacity.ts
+++ b/web/src/api/generated/model/capacity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/cause.ts
+++ b/web/src/api/generated/model/cause.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/changedWhat.ts
+++ b/web/src/api/generated/model/changedWhat.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/checkout.ts
+++ b/web/src/api/generated/model/checkout.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { PullState } from './pullState';
 import type { RepoId } from './repoId';

--- a/web/src/api/generated/model/checkoutSummary.ts
+++ b/web/src/api/generated/model/checkoutSummary.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { WorkSummary } from './workSummary';
 

--- a/web/src/api/generated/model/checkoutWork.ts
+++ b/web/src/api/generated/model/checkoutWork.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { PullState } from './pullState';
 

--- a/web/src/api/generated/model/choice.ts
+++ b/web/src/api/generated/model/choice.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/chosen.ts
+++ b/web/src/api/generated/model/chosen.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ControlKind } from './controlKind';
 

--- a/web/src/api/generated/model/clientFrame.ts
+++ b/web/src/api/generated/model/clientFrame.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Topic } from './topic';
 

--- a/web/src/api/generated/model/clientId.ts
+++ b/web/src/api/generated/model/clientId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/commit.ts
+++ b/web/src/api/generated/model/commit.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Commit {

--- a/web/src/api/generated/model/compute.ts
+++ b/web/src/api/generated/model/compute.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { SshKey } from './sshKey';
 

--- a/web/src/api/generated/model/configureAgent.ts
+++ b/web/src/api/generated/model/configureAgent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { AgentMode } from './agentMode';
 

--- a/web/src/api/generated/model/connected.ts
+++ b/web/src/api/generated/model/connected.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/control.ts
+++ b/web/src/api/generated/model/control.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Choice } from './choice';
 import type { ControlKind } from './controlKind';

--- a/web/src/api/generated/model/controlKind.ts
+++ b/web/src/api/generated/model/controlKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/controlPlaneTarget.ts
+++ b/web/src/api/generated/model/controlPlaneTarget.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { UpdaterView } from './updaterView';
 

--- a/web/src/api/generated/model/conversation.ts
+++ b/web/src/api/generated/model/conversation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ConversationEvent } from './conversationEvent';
 

--- a/web/src/api/generated/model/conversationEvent.ts
+++ b/web/src/api/generated/model/conversationEvent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { TurnEvent } from './turnEvent';
 

--- a/web/src/api/generated/model/createAccount.ts
+++ b/web/src/api/generated/model/createAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 import type { AgentMode } from './agentMode';

--- a/web/src/api/generated/model/credentials.ts
+++ b/web/src/api/generated/model/credentials.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Credentials {

--- a/web/src/api/generated/model/decision.ts
+++ b/web/src/api/generated/model/decision.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/deleteHostParams.ts
+++ b/web/src/api/generated/model/deleteHostParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type DeleteHostParams = {

--- a/web/src/api/generated/model/destroySessionParams.ts
+++ b/web/src/api/generated/model/destroySessionParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type DestroySessionParams = {

--- a/web/src/api/generated/model/diagnosis.ts
+++ b/web/src/api/generated/model/diagnosis.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Cause } from './cause';
 

--- a/web/src/api/generated/model/dockerState.ts
+++ b/web/src/api/generated/model/dockerState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { DockerStatus } from './dockerStatus';
 

--- a/web/src/api/generated/model/dockerStatus.ts
+++ b/web/src/api/generated/model/dockerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/done.ts
+++ b/web/src/api/generated/model/done.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Done {

--- a/web/src/api/generated/model/downloadFileParams.ts
+++ b/web/src/api/generated/model/downloadFileParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type DownloadFileParams = {

--- a/web/src/api/generated/model/drain.ts
+++ b/web/src/api/generated/model/drain.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Drain {

--- a/web/src/api/generated/model/elementSnapshot.ts
+++ b/web/src/api/generated/model/elementSnapshot.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface ElementSnapshot {

--- a/web/src/api/generated/model/endAll.ts
+++ b/web/src/api/generated/model/endAll.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/endedAll.ts
+++ b/web/src/api/generated/model/endedAll.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface EndedAll {

--- a/web/src/api/generated/model/envVariable.ts
+++ b/web/src/api/generated/model/envVariable.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface EnvVariable {

--- a/web/src/api/generated/model/errorCode.ts
+++ b/web/src/api/generated/model/errorCode.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/event.ts
+++ b/web/src/api/generated/model/event.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { EventKind } from './eventKind';
 import type { SessionId } from './sessionId';

--- a/web/src/api/generated/model/eventKind.ts
+++ b/web/src/api/generated/model/eventKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 import type { SessionStatus } from './sessionStatus';

--- a/web/src/api/generated/model/execution.ts
+++ b/web/src/api/generated/model/execution.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type Execution = typeof Execution[keyof typeof Execution];

--- a/web/src/api/generated/model/fallback.ts
+++ b/web/src/api/generated/model/fallback.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Fallback {

--- a/web/src/api/generated/model/fileChoice.ts
+++ b/web/src/api/generated/model/fileChoice.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface FileChoice {

--- a/web/src/api/generated/model/fileDiff.ts
+++ b/web/src/api/generated/model/fileDiff.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/fileEntry.ts
+++ b/web/src/api/generated/model/fileEntry.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/filePlan.ts
+++ b/web/src/api/generated/model/filePlan.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { FileVerdict } from './fileVerdict';
 

--- a/web/src/api/generated/model/fileVerdict.ts
+++ b/web/src/api/generated/model/fileVerdict.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type FileVerdict = typeof FileVerdict[keyof typeof FileVerdict];

--- a/web/src/api/generated/model/findFilesParams.ts
+++ b/web/src/api/generated/model/findFilesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type FindFilesParams = {

--- a/web/src/api/generated/model/forwarded.ts
+++ b/web/src/api/generated/model/forwarded.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/getConversationParams.ts
+++ b/web/src/api/generated/model/getConversationParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type GetConversationParams = {

--- a/web/src/api/generated/model/getTaskParams.ts
+++ b/web/src/api/generated/model/getTaskParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type GetTaskParams = {

--- a/web/src/api/generated/model/gitIdentity.ts
+++ b/web/src/api/generated/model/gitIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/heldSecret.ts
+++ b/web/src/api/generated/model/heldSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/host.ts
+++ b/web/src/api/generated/model/host.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Capacity } from './capacity';
 import type { Compute } from './compute';

--- a/web/src/api/generated/model/hostId.ts
+++ b/web/src/api/generated/model/hostId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/hostReadinessParams.ts
+++ b/web/src/api/generated/model/hostReadinessParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 

--- a/web/src/api/generated/model/hostState.ts
+++ b/web/src/api/generated/model/hostState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type HostState = typeof HostState[keyof typeof HostState];

--- a/web/src/api/generated/model/hostTarget.ts
+++ b/web/src/api/generated/model/hostTarget.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { TargetKind } from './targetKind';
 

--- a/web/src/api/generated/model/index.ts
+++ b/web/src/api/generated/model/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export * from './accessEntry';

--- a/web/src/api/generated/model/installAgent.ts
+++ b/web/src/api/generated/model/installAgent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/installed.ts
+++ b/web/src/api/generated/model/installed.ts
@@ -3,13 +3,19 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**
  * What answered after a worker was put there.
  */
 export interface Installed {
-  /** What `firetower-worker --version` said on the machine. */
-  version: string;
+  /**
+     * What `firetower-worker --version` said on the machine.
+     *
+     * Absent when the copy succeeded and the probe did not answer. The
+     * install still happened; the supervisor's next connection is the verdict.
+     * @nullable
+     */
+  version?: string | null;
 }

--- a/web/src/api/generated/model/itemId.ts
+++ b/web/src/api/generated/model/itemId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/itemKind.ts
+++ b/web/src/api/generated/model/itemKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/itemStatus.ts
+++ b/web/src/api/generated/model/itemStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/keepAnnotation.ts
+++ b/web/src/api/generated/model/keepAnnotation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ElementSnapshot } from './elementSnapshot';
 

--- a/web/src/api/generated/model/label.ts
+++ b/web/src/api/generated/model/label.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Label {

--- a/web/src/api/generated/model/limit.ts
+++ b/web/src/api/generated/model/limit.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Limit {

--- a/web/src/api/generated/model/listEventsParams.ts
+++ b/web/src/api/generated/model/listEventsParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type ListEventsParams = {

--- a/web/src/api/generated/model/listFilesParams.ts
+++ b/web/src/api/generated/model/listFilesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type ListFilesParams = {

--- a/web/src/api/generated/model/listSessionsParams.ts
+++ b/web/src/api/generated/model/listSessionsParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type ListSessionsParams = {

--- a/web/src/api/generated/model/listTasksParams.ts
+++ b/web/src/api/generated/model/listTasksParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { TaskKind } from './taskKind';
 import type { TaskState } from './taskState';

--- a/web/src/api/generated/model/me.ts
+++ b/web/src/api/generated/model/me.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Organization } from './organization';
 import type { User } from './user';

--- a/web/src/api/generated/model/modelUsage.ts
+++ b/web/src/api/generated/model/modelUsage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/nameOrganization.ts
+++ b/web/src/api/generated/model/nameOrganization.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface NameOrganization {

--- a/web/src/api/generated/model/newCheckout.ts
+++ b/web/src/api/generated/model/newCheckout.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { RepoId } from './repoId';
 

--- a/web/src/api/generated/model/newEnv.ts
+++ b/web/src/api/generated/model/newEnv.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { EnvVariable } from './envVariable';
 

--- a/web/src/api/generated/model/newForward.ts
+++ b/web/src/api/generated/model/newForward.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface NewForward {

--- a/web/src/api/generated/model/newHost.ts
+++ b/web/src/api/generated/model/newHost.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Compute } from './compute';
 

--- a/web/src/api/generated/model/newPassword.ts
+++ b/web/src/api/generated/model/newPassword.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface NewPassword {

--- a/web/src/api/generated/model/newPullRequest.ts
+++ b/web/src/api/generated/model/newPullRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface NewPullRequest {

--- a/web/src/api/generated/model/newRepo.ts
+++ b/web/src/api/generated/model/newRepo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/newRun.ts
+++ b/web/src/api/generated/model/newRun.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { FileChoice } from './fileChoice';
 

--- a/web/src/api/generated/model/newSession.ts
+++ b/web/src/api/generated/model/newSession.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 import type { HostId } from './hostId';

--- a/web/src/api/generated/model/orgId.ts
+++ b/web/src/api/generated/model/orgId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/organization.ts
+++ b/web/src/api/generated/model/organization.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { OrgId } from './orgId';
 

--- a/web/src/api/generated/model/page.ts
+++ b/web/src/api/generated/model/page.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Task } from './task';
 

--- a/web/src/api/generated/model/pendingAuth.ts
+++ b/web/src/api/generated/model/pendingAuth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/person.ts
+++ b/web/src/api/generated/model/person.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Person {

--- a/web/src/api/generated/model/placed.ts
+++ b/web/src/api/generated/model/placed.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Placed {

--- a/web/src/api/generated/model/planRequest.ts
+++ b/web/src/api/generated/model/planRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface PlanRequest {

--- a/web/src/api/generated/model/planStep.ts
+++ b/web/src/api/generated/model/planStep.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { PlanStepStatus } from './planStepStatus';
 

--- a/web/src/api/generated/model/planStepStatus.ts
+++ b/web/src/api/generated/model/planStepStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type PlanStepStatus = typeof PlanStepStatus[keyof typeof PlanStepStatus];

--- a/web/src/api/generated/model/ports.ts
+++ b/web/src/api/generated/model/ports.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Forwarded } from './forwarded';
 

--- a/web/src/api/generated/model/previewAddress.ts
+++ b/web/src/api/generated/model/previewAddress.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/previewAddressParams.ts
+++ b/web/src/api/generated/model/previewAddressParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type PreviewAddressParams = {

--- a/web/src/api/generated/model/previewAnnotation.ts
+++ b/web/src/api/generated/model/previewAnnotation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ElementSnapshot } from './elementSnapshot';
 

--- a/web/src/api/generated/model/probeRequest.ts
+++ b/web/src/api/generated/model/probeRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface ProbeRequest {

--- a/web/src/api/generated/model/probeResponse.ts
+++ b/web/src/api/generated/model/probeResponse.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/proposal.ts
+++ b/web/src/api/generated/model/proposal.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Proposal {

--- a/web/src/api/generated/model/providerStatus.ts
+++ b/web/src/api/generated/model/providerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { PendingAuth } from './pendingAuth';
 

--- a/web/src/api/generated/model/publicIdentity.ts
+++ b/web/src/api/generated/model/publicIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/pullRequest.ts
+++ b/web/src/api/generated/model/pullRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface PullRequest {

--- a/web/src/api/generated/model/pullState.ts
+++ b/web/src/api/generated/model/pullState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/question.ts
+++ b/web/src/api/generated/model/question.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { QuestionOption } from './questionOption';
 

--- a/web/src/api/generated/model/questionOption.ts
+++ b/web/src/api/generated/model/questionOption.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/rawSource.ts
+++ b/web/src/api/generated/model/rawSource.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/reached.ts
+++ b/web/src/api/generated/model/reached.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Diagnosis } from './diagnosis';
 

--- a/web/src/api/generated/model/readiness.ts
+++ b/web/src/api/generated/model/readiness.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Requirement } from './requirement';
 

--- a/web/src/api/generated/model/release.ts
+++ b/web/src/api/generated/model/release.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/remoteRepo.ts
+++ b/web/src/api/generated/model/remoteRepo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/rename.ts
+++ b/web/src/api/generated/model/rename.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Rename {

--- a/web/src/api/generated/model/renameSession.ts
+++ b/web/src/api/generated/model/renameSession.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface RenameSession {

--- a/web/src/api/generated/model/replaceSecret.ts
+++ b/web/src/api/generated/model/replaceSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface ReplaceSecret {

--- a/web/src/api/generated/model/repo.ts
+++ b/web/src/api/generated/model/repo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { RepoId } from './repoId';
 

--- a/web/src/api/generated/model/repoChanges.ts
+++ b/web/src/api/generated/model/repoChanges.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/repoId.ts
+++ b/web/src/api/generated/model/repoId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/requestId.ts
+++ b/web/src/api/generated/model/requestId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/requestKind.ts
+++ b/web/src/api/generated/model/requestKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/requirement.ts
+++ b/web/src/api/generated/model/requirement.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Requirement {

--- a/web/src/api/generated/model/revealedSecret.ts
+++ b/web/src/api/generated/model/revealedSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/rotated.ts
+++ b/web/src/api/generated/model/rotated.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/runState.ts
+++ b/web/src/api/generated/model/runState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type RunState = typeof RunState[keyof typeof RunState];

--- a/web/src/api/generated/model/scopeKind.ts
+++ b/web/src/api/generated/model/scopeKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/sent.ts
+++ b/web/src/api/generated/model/sent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Sent {

--- a/web/src/api/generated/model/serverFrame.ts
+++ b/web/src/api/generated/model/serverFrame.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { EventKind } from './eventKind';
 import type { SessionId } from './sessionId';

--- a/web/src/api/generated/model/session.ts
+++ b/web/src/api/generated/model/session.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Agent } from './agent';
 import type { Checkout } from './checkout';

--- a/web/src/api/generated/model/sessionAccount.ts
+++ b/web/src/api/generated/model/sessionAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Account } from './account';
 import type { Limit } from './limit';

--- a/web/src/api/generated/model/sessionDiffParams.ts
+++ b/web/src/api/generated/model/sessionDiffParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type SessionDiffParams = {

--- a/web/src/api/generated/model/sessionId.ts
+++ b/web/src/api/generated/model/sessionId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/sessionPtyParams.ts
+++ b/web/src/api/generated/model/sessionPtyParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type SessionPtyParams = {

--- a/web/src/api/generated/model/sessionStatus.ts
+++ b/web/src/api/generated/model/sessionStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type SessionStatus = typeof SessionStatus[keyof typeof SessionStatus];

--- a/web/src/api/generated/model/setIdentity.ts
+++ b/web/src/api/generated/model/setIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/setShare.ts
+++ b/web/src/api/generated/model/setShare.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Share } from './share';
 

--- a/web/src/api/generated/model/setupState.ts
+++ b/web/src/api/generated/model/setupState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Organization } from './organization';
 

--- a/web/src/api/generated/model/share.ts
+++ b/web/src/api/generated/model/share.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/signIn.ts
+++ b/web/src/api/generated/model/signIn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/signedIn.ts
+++ b/web/src/api/generated/model/signedIn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { User } from './user';
 

--- a/web/src/api/generated/model/slashCommand.ts
+++ b/web/src/api/generated/model/slashCommand.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/sshKey.ts
+++ b/web/src/api/generated/model/sshKey.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/step.ts
+++ b/web/src/api/generated/model/step.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/stepState.ts
+++ b/web/src/api/generated/model/stepState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type StepState = typeof StepState[keyof typeof StepState];

--- a/web/src/api/generated/model/storedEnv.ts
+++ b/web/src/api/generated/model/storedEnv.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/streamKind.ts
+++ b/web/src/api/generated/model/streamKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/switch.ts
+++ b/web/src/api/generated/model/switch.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Switch {

--- a/web/src/api/generated/model/switchAccount.ts
+++ b/web/src/api/generated/model/switchAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface SwitchAccount {

--- a/web/src/api/generated/model/switchedAccount.ts
+++ b/web/src/api/generated/model/switchedAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface SwitchedAccount {

--- a/web/src/api/generated/model/targetKind.ts
+++ b/web/src/api/generated/model/targetKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type TargetKind = typeof TargetKind[keyof typeof TargetKind];

--- a/web/src/api/generated/model/targets.ts
+++ b/web/src/api/generated/model/targets.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface Targets {

--- a/web/src/api/generated/model/task.ts
+++ b/web/src/api/generated/model/task.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Label } from './label';
 import type { Person } from './person';

--- a/web/src/api/generated/model/taskId.ts
+++ b/web/src/api/generated/model/taskId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/taskKind.ts
+++ b/web/src/api/generated/model/taskKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/taskScope.ts
+++ b/web/src/api/generated/model/taskScope.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/taskState.ts
+++ b/web/src/api/generated/model/taskState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type TaskState = typeof TaskState[keyof typeof TaskState];

--- a/web/src/api/generated/model/topic.ts
+++ b/web/src/api/generated/model/topic.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/trackerKey.ts
+++ b/web/src/api/generated/model/trackerKey.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface TrackerKey {

--- a/web/src/api/generated/model/trackerStatus.ts
+++ b/web/src/api/generated/model/trackerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Auth } from './auth';
 import type { ScopeKind } from './scopeKind';

--- a/web/src/api/generated/model/turn.ts
+++ b/web/src/api/generated/model/turn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Attached } from './attached';
 

--- a/web/src/api/generated/model/turnEvent.ts
+++ b/web/src/api/generated/model/turnEvent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { Decision } from './decision';
 import type { ItemId } from './itemId';

--- a/web/src/api/generated/model/turnId.ts
+++ b/web/src/api/generated/model/turnId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/turnStatus.ts
+++ b/web/src/api/generated/model/turnStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/updateAccount.ts
+++ b/web/src/api/generated/model/updateAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export interface UpdateAccount {

--- a/web/src/api/generated/model/updateRun.ts
+++ b/web/src/api/generated/model/updateRun.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { RunState } from './runState';
 import type { Targets } from './targets';

--- a/web/src/api/generated/model/updateStatus.ts
+++ b/web/src/api/generated/model/updateStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ControlPlaneTarget } from './controlPlaneTarget';
 import type { HostTarget } from './hostTarget';

--- a/web/src/api/generated/model/updateStep.ts
+++ b/web/src/api/generated/model/updateStep.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { StepState } from './stepState';
 

--- a/web/src/api/generated/model/updaterView.ts
+++ b/web/src/api/generated/model/updaterView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/upgradePlan.ts
+++ b/web/src/api/generated/model/upgradePlan.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { FilePlan } from './filePlan';
 

--- a/web/src/api/generated/model/usage.ts
+++ b/web/src/api/generated/model/usage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { ModelUsage } from './modelUsage';
 

--- a/web/src/api/generated/model/user.ts
+++ b/web/src/api/generated/model/user.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { OrgId } from './orgId';
 import type { UserId } from './userId';

--- a/web/src/api/generated/model/userId.ts
+++ b/web/src/api/generated/model/userId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/vaultView.ts
+++ b/web/src/api/generated/model/vaultView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import type { AccessEntry } from './accessEntry';
 import type { HeldSecret } from './heldSecret';

--- a/web/src/api/generated/model/workSummary.ts
+++ b/web/src/api/generated/model/workSummary.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/workspaceId.ts
+++ b/web/src/api/generated/model/workspaceId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/model/workspaceSize.ts
+++ b/web/src/api/generated/model/workspaceSize.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 export type WorkspaceSize = typeof WorkspaceSize[keyof typeof WorkspaceSize];

--- a/web/src/api/generated/model/workspaceUsage.ts
+++ b/web/src/api/generated/model/workspaceUsage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 
 /**

--- a/web/src/api/generated/providers/providers.ts
+++ b/web/src/api/generated/providers/providers.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/providers/providers.zod.ts
+++ b/web/src/api/generated/providers/providers.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/repos/repos.ts
+++ b/web/src/api/generated/repos/repos.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/repos/repos.zod.ts
+++ b/web/src/api/generated/repos/repos.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/secrets/secrets.ts
+++ b/web/src/api/generated/secrets/secrets.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/secrets/secrets.zod.ts
+++ b/web/src/api/generated/secrets/secrets.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/sessions/sessions.ts
+++ b/web/src/api/generated/sessions/sessions.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/sessions/sessions.zod.ts
+++ b/web/src/api/generated/sessions/sessions.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/setup/setup.ts
+++ b/web/src/api/generated/setup/setup.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/setup/setup.zod.ts
+++ b/web/src/api/generated/setup/setup.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/stream/stream.ts
+++ b/web/src/api/generated/stream/stream.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useQuery,

--- a/web/src/api/generated/stream/stream.zod.ts
+++ b/web/src/api/generated/stream/stream.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/tasks/tasks.ts
+++ b/web/src/api/generated/tasks/tasks.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useQuery,

--- a/web/src/api/generated/tasks/tasks.zod.ts
+++ b/web/src/api/generated/tasks/tasks.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/trackers/trackers.ts
+++ b/web/src/api/generated/trackers/trackers.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/trackers/trackers.zod.ts
+++ b/web/src/api/generated/trackers/trackers.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/updates/updates.ts
+++ b/web/src/api/generated/updates/updates.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import {
   useMutation,

--- a/web/src/api/generated/updates/updates.zod.ts
+++ b/web/src/api/generated/updates/updates.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.31.0
+ * OpenAPI spec version: 0.32.0
  */
 import * as zod from 'zod';
 


### PR DESCRIPTION
`03aff30` gave the remote worker command a `PATH=$HOME/.firetower/worker/bin:$PATH`
prefix. That one string broke connecting to a worker three different ways, and
took the auto-install path down with it.

## Container-mode workers stopped answering entirely

`docker exec` takes a program and its arguments, not a shell line — env goes
through `-e`. The first non-flag word after the container name is the command,
so Docker tried to exec a file literally named `PATH=…`. Against a live
container:

```
OCI runtime exec failed: exec failed: unable to start container process:
exec: "PATH=/tmp:/usr/bin": stat PATH=/tmp:/usr/bin: no such file or directory
```

Docker exits 126, which `diagnose` reads as command-not-found, so the answer
came back as **"That container is running, and it isn't a Firetower worker"**
with `docker compose pull` beside it — pointing at the image over a bug in our
own argv. A container is now sent the bare program name, as it was before.

## A login shell that is not `sh` never ran anything

Elsewhere the prefix reached the SSH account's login shell. `csh`, `tcsh` and
`fish` reject `VAR=value command` outright:

```
PATH=/home/x/.firetower/worker/bin:/usr/bin: Command not found.
```

Indistinguishable, from here, from a machine with no worker on it — which is
what the screen said. A direct host now goes through `sh -c`, so the syntax is
one this end chose rather than one the account happens to have.

## The installed directory shadowed a worker somebody installed themselves

It went on the *front* of PATH. `install.rs`, the test beside it and
`docs/host-execution.md` all say it goes last so an operator's own copy still
wins. It does now.

Verified against real shells:

| | before | after |
|---|---|---|
| bash, operator's worker on PATH | Firetower's copy — shadowed | operator's copy |
| csh | `Command not found.`, exit 1 | operator's copy |
| nothing else on PATH | Firetower's copy | Firetower's copy |
| container | `exec: "PATH=…"` | the worker |

## `firetower worker --version` was not a thing

The control-plane image carries one binary, so `install::source_from` never
finds a sibling `firetower-worker` and always sends that binary under a wrapper
turning `firetower-worker --version` into `firetower worker --version`. clap
keeps `--version` on the root command unless told to propagate it, so:

```
error: unexpected argument '--version' found
Usage: firetower worker [OPTIONS]
```

The copy had already succeeded — only the probe failed, and bailing on it meant
`try_now` never ran, so nothing retried. `propagate_version = true` fixes the
probe; the copy and the probe are now separate outcomes, and one that does not
answer leaves `version` unset and still wakes the supervisor.

Adding the worker binary to the image would also have fixed it, at +30 MB on an
image that never runs it. Not worth it for one clap attribute.

## Also, on the compute form

The SSH address and account are two fields again, and the container name is
collected once more — folded into one box there was no way to name a container
anything but `firetower-worker`. Pasting a whole `user@host` destination into
the address still works: `parseDestination` splits it and the server prefers a
field somebody filled in over one it parsed, so no API change was needed.

New workspace opens on **Container** rather than on whichever environment the
machine's list happened to hold first.

## Tests

New: the container form carries no `PATH=` word, the direct form appends and
goes through `sh`, a root is quoted, the probe resolves the same binary a
session would, an OCI exec of the wrong thing blames Firetower rather than the
image, and `defaultMode` is Container unless the machine only runs on the host.

17/17 transport, 14/14 diagnose, 212 web. `cargo fmt`, `just check-style`,
`pnpm lint` and `pnpm tsc` clean. `just gen` also picked up a stale
`0.31.0 → 0.32.0` header across the generated client that the last release
never regenerated.

Two pre-existing failures untouched by this: `capacity::a_machine_reports_memory_it_could_actually_have`
fails on `main` too, and `agents::present_agrees_with_what_probing_found` is
flaky. `just lint` is already red on `main` with 14 clippy errors in
`accounts.rs`, `conversation.rs`, `db.rs` and `sessions.rs` — none in files
this touches.

## Still to do on the running fleet

A host that already had a failed install is carrying the shadowing wrapper, and
this release does not remove it. To unblock one now:

```sh
ssh <account>@<host> 'rm -rf ~/.firetower/worker/bin'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEyQPx58L3Tn4uNjcvLgm
