### PR TITLE
fix(updates): upgrade from the control plane again

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -10,7 +10,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.32.0"
+    "version": "0.32.1"
   },
   "paths": {
     "/api/v1/agent-accounts": {
@@ -4565,6 +4565,38 @@
         }
       }
     },
+    "/api/v1/updates/backup": {
+      "post": {
+        "tags": [
+          "updates"
+        ],
+        "summary": "Take a backup now, outside an upgrade.",
+        "description": "Until this existed a backup only ever ran inside an upgrade, so there was\nno way to find out it was broken except by trying to upgrade — which is how\none got found.",
+        "operationId": "back_up_now",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/updates/check": {
       "post": {
         "tags": [
@@ -4749,6 +4781,59 @@
         "summary": "Stop a run that has not started changing anything yet.",
         "description": "A run that is waiting for machines to be idle is cancelled and the\nmachines put back in service. One that is already recreating something is\nleft to finish that step — half a recreate is worse than a whole one.",
         "operationId": "cancel_run",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Run id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateRun"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/updates/runs/{id}/continue": {
+      "post": {
+        "tags": [
+          "updates"
+        ],
+        "summary": "Carry on with a run that stopped to ask.",
+        "description": "Only a run waiting on the backup reaches this, and the answer is always the\nsame one: go ahead without a backup. Its step keeps the `Warned` state, so\nthe history says the upgrade went ahead without one.",
+        "operationId": "continue_run",
         "parameters": [
           {
             "name": "id",
@@ -8073,6 +8158,7 @@
         "enum": [
           "planned",
           "waitingIdle",
+          "waitingDecision",
           "running",
           "succeeded",
           "failed",
@@ -8705,6 +8791,7 @@
           "running",
           "done",
           "failed",
+          "warned",
           "skipped"
         ]
       },

--- a/api/updater.json
+++ b/api/updater.json
@@ -10,7 +10,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.32.0"
+    "version": "0.32.1"
   },
   "paths": {
     "/v1/deploy": {

--- a/crates/ft-server/src/api.rs
+++ b/crates/ft-server/src/api.rs
@@ -361,6 +361,8 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(updates::list_runs, updates::create_run))
         .routes(routes!(updates::get_run))
         .routes(routes!(updates::cancel_run))
+        .routes(routes!(updates::continue_run))
+        .routes(routes!(updates::back_up_now))
         .routes(routes!(tasks::get_task))
         .routes(routes!(trackers::list_trackers))
         .routes(routes!(trackers::set_tracker_key))

--- a/crates/ft-server/src/api/updates.rs
+++ b/crates/ft-server/src/api/updates.rs
@@ -293,6 +293,66 @@ pub(super) async fn cancel_run(
     Ok(Json(read_run(&state, &id).await?))
 }
 
+/// Carry on with a run that stopped to ask.
+///
+/// Only a run waiting on the backup reaches this, and the answer is always the
+/// same one: go ahead without a backup. Its step keeps the `Warned` state, so
+/// the history says the upgrade went ahead without one.
+#[utoipa::path(
+    post, path = "/api/v1/updates/runs/{id}/continue", tag = "updates",
+    params(("id" = String, Path, description = "Run id")),
+    responses((status = 200, body = UpdateRun), (status = 404, body = ApiError), (status = 409, body = ApiError)),
+)]
+pub(super) async fn continue_run(
+    State(state): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<UpdateRun>> {
+    admin_only(&principal)?;
+    let run = read_run(&state, &id).await?;
+    if run.state != crate::updates::RunState::WaitingDecision {
+        return Err(ApiError::new(
+            ErrorCode::ActionFailed,
+            "this run is not waiting for an answer",
+        ));
+    }
+    state
+        .updates
+        .store
+        .set_run_state(&id, crate::updates::RunState::Running)
+        .await?;
+    crate::updates::runs::spawn(state.clone(), id.clone()).await;
+    Ok(Json(read_run(&state, &id).await?))
+}
+
+/// Take a backup now, outside an upgrade.
+///
+/// Until this existed a backup only ever ran inside an upgrade, so there was
+/// no way to find out it was broken except by trying to upgrade — which is how
+/// one got found.
+#[utoipa::path(
+    post, path = "/api/v1/updates/backup", tag = "updates",
+    responses((status = 200, body = String), (status = 409, body = ApiError)),
+)]
+pub(super) async fn back_up_now(
+    State(state): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<String>> {
+    admin_only(&principal)?;
+    let updater = state
+        .updates
+        .updater
+        .as_ref()
+        .map_err(|absent| ApiError::new(ErrorCode::ActionFailed, absent.explain()))?;
+    let job = updater
+        .start(ft_updater_api::JobKind::Backup {
+            from_version: env!("CARGO_PKG_VERSION").to_string(),
+        })
+        .await
+        .map_err(|e| ApiError::new(ErrorCode::ActionFailed, format!("{e:#}")))?;
+    Ok(Json(job.id.0))
+}
+
 async fn read_run(state: &AppState, id: &str) -> ApiResult<UpdateRun> {
     let run = state
         .updates

--- a/crates/ft-server/src/updates/mod.rs
+++ b/crates/ft-server/src/updates/mod.rs
@@ -89,6 +89,12 @@ impl Updates {
 pub enum RunState {
     Planned,
     WaitingIdle,
+    /// Stopped part-way, waiting for somebody to say whether to carry on.
+    ///
+    /// Only the backup reaches this. An upgrade with no backup is a decision,
+    /// and it belongs to the person pressing the button rather than to a step
+    /// that failed for its own reasons.
+    WaitingDecision,
     Running,
     Succeeded,
     Failed,
@@ -100,6 +106,7 @@ impl RunState {
         match self {
             RunState::Planned => "planned",
             RunState::WaitingIdle => "waiting_idle",
+            RunState::WaitingDecision => "waiting_decision",
             RunState::Running => "running",
             RunState::Succeeded => "succeeded",
             RunState::Failed => "failed",
@@ -111,6 +118,7 @@ impl RunState {
         Some(match s {
             "planned" => RunState::Planned,
             "waiting_idle" => RunState::WaitingIdle,
+            "waiting_decision" => RunState::WaitingDecision,
             "running" => RunState::Running,
             "succeeded" => RunState::Succeeded,
             "failed" => RunState::Failed,
@@ -134,6 +142,12 @@ pub enum StepState {
     Running,
     Done,
     Failed,
+    /// Did not do what it was for, and the run goes on anyway.
+    ///
+    /// A backup that cannot be taken is worth knowing about and worth
+    /// recording — the run's history should say it went ahead without one —
+    /// but it is not a reason the upgrade cannot happen.
+    Warned,
     Skipped,
 }
 
@@ -144,6 +158,7 @@ impl StepState {
             StepState::Running => "running",
             StepState::Done => "done",
             StepState::Failed => "failed",
+            StepState::Warned => "warned",
             StepState::Skipped => "skipped",
         }
     }
@@ -154,6 +169,7 @@ impl StepState {
             "running" => StepState::Running,
             "done" => StepState::Done,
             "failed" => StepState::Failed,
+            "warned" => StepState::Warned,
             "skipped" => StepState::Skipped,
             _ => return None,
         })
@@ -352,6 +368,7 @@ mod tests {
             RunState::Succeeded,
             RunState::Failed,
             RunState::Cancelled,
+            RunState::WaitingDecision,
         ] {
             assert_eq!(RunState::from_db(s.as_db()), Some(s));
         }
@@ -360,10 +377,18 @@ mod tests {
             StepState::Running,
             StepState::Done,
             StepState::Failed,
+            StepState::Warned,
             StepState::Skipped,
         ] {
             assert_eq!(StepState::from_db(s.as_db()), Some(s));
         }
         assert!(RunState::from_db("nonsense").is_none());
+    }
+
+    /// A run stopped for an answer has not finished, and the screen has to
+    /// keep showing it — there is nowhere else to give the answer.
+    #[test]
+    fn a_run_waiting_for_an_answer_is_not_over() {
+        assert!(!RunState::WaitingDecision.is_over());
     }
 }

--- a/crates/ft-server/src/updates/runs.rs
+++ b/crates/ft-server/src/updates/runs.rs
@@ -94,6 +94,11 @@ async fn drive(state: &AppState, store: &Store, run_id: &str) -> Result<()> {
     if run.state.is_over() {
         return Ok(());
     }
+    // Somebody has to say whether to go on without a backup. Nothing decides
+    // that on its own, including a restart of this process.
+    if run.state == RunState::WaitingDecision {
+        return Ok(());
+    }
 
     if run.when_idle && matches!(run.state, RunState::Planned | RunState::WaitingIdle) {
         store.set_run_state(run_id, RunState::WaitingIdle).await?;
@@ -116,7 +121,10 @@ async fn drive(state: &AppState, store: &Store, run_id: &str) -> Result<()> {
     }
 
     for step in store.steps(run_id).await? {
-        if matches!(step.state, StepState::Done | StepState::Skipped) {
+        if matches!(
+            step.state,
+            StepState::Done | StepState::Skipped | StepState::Warned
+        ) {
             continue;
         }
         if is_cancelled(store, run_id).await? {
@@ -151,6 +159,26 @@ async fn drive(state: &AppState, store: &Store, run_id: &str) -> Result<()> {
                 store
                     .end_step(run_id, step.position, StepState::Done, Some(detail))
                     .await?
+            }
+            // A backup is a precaution, not the upgrade. When it cannot be
+            // taken the run stops and asks, rather than ending — which is what
+            // left the Updates screen with no way past a database `pg_dump`
+            // could not read, and the CLI as the only route.
+            Err(e) if step.target == BACKUP => {
+                let said = format!("{e:#}");
+                log.say(&said).await;
+                log.say("the upgrade is waiting: carry on without a backup, or stop")
+                    .await;
+                store
+                    .end_step(run_id, step.position, StepState::Warned, Some(said))
+                    .await?;
+                store
+                    .set_run_state(run_id, RunState::WaitingDecision)
+                    .await?;
+                // Deliberately no `put_back`: the run has not finished, and
+                // undraining now would let work onto a machine that is about
+                // to be upgraded.
+                return Ok(());
             }
             Err(e) => {
                 let said = format!("{e:#}");
@@ -614,6 +642,9 @@ pub async fn resume(state: AppState) {
         }
     };
     for run in runs {
+        if run.state == RunState::WaitingDecision {
+            continue;
+        }
         let steps = match store.steps(&run.id).await {
             Ok(s) => s,
             Err(e) => {

--- a/crates/ft-server/src/updates/store.rs
+++ b/crates/ft-server/src/updates/store.rs
@@ -203,7 +203,11 @@ impl Store {
     /// Runs that are not over. Normally none or one.
     pub async fn active_runs(&self) -> Result<Vec<Run>> {
         sqlx::query(
-            "SELECT * FROM update_runs WHERE state IN ('planned', 'waiting_idle', 'running')
+            // `waiting_decision` among them: a run stopped for an answer is
+            // still this deployment's upgrade, and the screen has to show it
+            // or there is nowhere to give the answer.
+            "SELECT * FROM update_runs
+              WHERE state IN ('planned', 'waiting_idle', 'running', 'waiting_decision')
              ORDER BY created_at",
         )
         .fetch_all(&self.pool)

--- a/crates/ft-updater/src/docker.rs
+++ b/crates/ft-updater/src/docker.rs
@@ -35,6 +35,10 @@ const HEADERS_TIMEOUT: Duration = Duration::from_secs(120);
 /// pull that has stalled, an exec that hung.
 const IDLE_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// The most of a command's stderr worth keeping. Enough for any real error and
+/// its context; far less than one statement naming every table in a database.
+pub const STDERR_KEPT: usize = 64 * 1024;
+
 #[derive(Clone)]
 pub struct Docker {
     socket: std::path::PathBuf,
@@ -374,6 +378,7 @@ impl Docker {
         let mut body = response.into_body();
         let mut pending: Vec<u8> = Vec::new();
         let mut stderr: Vec<u8> = Vec::new();
+        let mut dropped: usize = 0;
         loop {
             let next = tokio::time::timeout(IDLE_TIMEOUT, body.frame())
                 .await
@@ -396,7 +401,20 @@ impl Docker {
                 pending.drain(..8 + size);
                 match kind {
                     1 => sink.write_all(&payload).await?,
-                    _ => stderr.extend_from_slice(&payload),
+                    // Bounded. `pg_dump` failing on a database full of
+                    // schemas writes one line naming every table in it, and
+                    // this used to be kept whole — through the job's error,
+                    // the run log, the database and onto the screen. The tail
+                    // is the half worth keeping: that is where `ERROR:` and
+                    // `HINT:` end up.
+                    _ => {
+                        stderr.extend_from_slice(&payload);
+                        if stderr.len() > STDERR_KEPT {
+                            let cut = stderr.len() - STDERR_KEPT;
+                            stderr.drain(..cut);
+                            dropped += cut;
+                        }
+                    }
                 }
             }
         }
@@ -410,7 +428,15 @@ impl Docker {
             .get("ExitCode")
             .and_then(Value::as_i64)
             .unwrap_or(-1);
-        Ok((code, String::from_utf8_lossy(&stderr).into_owned()))
+        let said = String::from_utf8_lossy(&stderr).into_owned();
+        Ok((
+            code,
+            if dropped > 0 {
+                format!("… {dropped} earlier bytes not shown …\n{said}")
+            } else {
+                said
+            },
+        ))
     }
 
     // ── plumbing ───────────────────────────────────────────────────────

--- a/crates/ft-updater/src/jobs.rs
+++ b/crates/ft-updater/src/jobs.rs
@@ -30,6 +30,7 @@ use crate::site::Site;
 use anyhow::{anyhow, Context, Result};
 use ft_updater_api::{FileWrite, Job, JobId, JobKind, JobState, JobStep};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -39,6 +40,11 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(180);
 /// How many log lines a job keeps. Enough for a pull and a compose run; bounded
 /// so a helper that prints in a loop cannot grow it without limit.
 const LOG_LINES: usize = 400;
+
+/// How many dumps to keep. A dump of this database is small, and ten upgrades
+/// back is further than anybody has ever restored from. Nothing pruned them
+/// before, so `backups/` grew until the disk did not.
+const KEEP_DUMPS: usize = 10;
 
 /// A label on every helper container, so a leftover one is recognisably ours.
 pub const HELPER_LABEL: &str = "com.firetower.updater";
@@ -228,6 +234,22 @@ impl Jobs {
             .context("no database container in this project")?;
         say.done(db.name.clone());
 
+        // What else is in there. A database somebody has run the test suite
+        // against carries a `test_*` schema per test, forever — the sweeper
+        // that removes them is `#[cfg(test)]`, so no release build has ever
+        // cleaned one up. The dump below skips them; this is so the screen
+        // says why the database is the size it is, before it gets bad enough
+        // to matter again.
+        match self.foreign_schemas(&db.id).await {
+            Ok(0) => {}
+            Ok(n) => say.say(format!(
+                "{n} schemas in this database that Firetower did not create. \
+                 The backup skips them. See docs/updates.md#schemas-firetower-did-not-create to clear them."
+            )),
+            // Never fatal. This is a remark, not a check.
+            Err(e) => tracing::debug!("could not count schemas: {e:#}"),
+        }
+
         say.step("pg_dump");
         let dir = self.site.backups_dir()?;
         let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
@@ -247,7 +269,21 @@ impl Jobs {
                 &[
                     "sh",
                     "-c",
-                    "pg_dump -U \"${POSTGRES_USER:-firetower}\" -d \"${POSTGRES_DB:-firetower}\" -Fc",
+                    // `-n public`, not the whole database. Everything every
+                    // migration makes is in `public`, and it is the only
+                    // schema a restore needs — while a database that has had
+                    // the test suite pointed at it holds thousands more.
+                    //
+                    // `pg_dump` takes `ACCESS SHARE` on everything it will
+                    // dump in one statement, so the whole-database form put
+                    // every table in the database into a single `LOCK TABLE`
+                    // and fell over `max_locks_per_transaction`; before that
+                    // it ran out of memory building the object graph. Both
+                    // scale with what is dumped, and this is what decides it.
+                    //
+                    // `-n` carries no roles or database-level grants. Neither
+                    // did the old command — only `pg_dumpall` emits those.
+                    "pg_dump -U \"${POSTGRES_USER:-firetower}\" -d \"${POSTGRES_DB:-firetower}\" -n public -Fc",
                 ],
                 &mut file,
             )
@@ -256,7 +292,7 @@ impl Jobs {
 
         if code != 0 {
             let _ = tokio::fs::remove_file(&temporary).await;
-            return Err(anyhow!("pg_dump exited {code}: {}", stderr.trim()));
+            return Err(anyhow!("{}", dump_failure(code, &stderr)));
         }
         tokio::fs::rename(&temporary, &path)
             .await
@@ -267,7 +303,40 @@ impl Jobs {
             .unwrap_or(0);
         say.done(format!("backups/{name} ({})", human(size)));
         say.say(format!("wrote backups/{name}"));
+
+        // After the rename, never before: a prune that runs first and then
+        // fails to dump has traded a backup for nothing.
+        for line in prune(&dir, KEEP_DUMPS).await {
+            say.say(line);
+        }
         Ok(JobState::Done)
+    }
+
+    /// How many schemas are in there that Firetower did not make.
+    ///
+    /// Everything of ours is in `public`. `pg_catalog`, `information_schema`
+    /// and `pg_toast*` are the server's own.
+    async fn foreign_schemas(&self, container: &str) -> Result<i64> {
+        let mut out = Vec::new();
+        let (code, stderr) = self
+            .docker
+            .exec(
+                container,
+                &[
+                    "sh",
+                    "-c",
+                    "psql -U \"${POSTGRES_USER:-firetower}\" -d \"${POSTGRES_DB:-firetower}\" -tAc \
+                     \"SELECT count(*) FROM information_schema.schemata \
+                       WHERE schema_name NOT IN ('public','information_schema') \
+                         AND schema_name NOT LIKE 'pg\\_%'\"",
+                ],
+                &mut out,
+            )
+            .await?;
+        if code != 0 {
+            return Err(anyhow!("psql exited {code}: {}", clip(&stderr, 400)));
+        }
+        Ok(String::from_utf8_lossy(&out).trim().parse().unwrap_or(0))
     }
 
     // ── the updater itself ─────────────────────────────────────────────
@@ -629,6 +698,125 @@ pub fn is_pinned(tag: &str) -> bool {
             .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
 }
 
+/// Keep the newest `keep` dumps, and sweep the remains of killed ones.
+///
+/// Only `firetower-*.dump` and `*.writing` are ever candidates: this is a
+/// bind-mounted directory on somebody's server and nothing else in it is ours.
+///
+/// A `.writing` file is what a dump that was *killed* leaves — the failure
+/// path deletes its own temporary, but an out-of-memory `pg_dump` never
+/// reaches it. A day is long enough that no dump in progress is caught.
+async fn prune(dir: &std::path::Path, keep: usize) -> Vec<String> {
+    let mut said = Vec::new();
+    let mut dumps: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    let mut writing: Vec<PathBuf> = Vec::new();
+
+    let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
+        return said;
+    };
+    let day_ago = std::time::SystemTime::now() - Duration::from_secs(24 * 60 * 60);
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Ok(made) = entry.metadata().await.and_then(|m| m.modified()) else {
+            continue;
+        };
+        if name.ends_with(".writing") {
+            if made < day_ago {
+                writing.push(path);
+            }
+        } else if name.starts_with("firetower-") && name.ends_with(".dump") {
+            dumps.push((made, path));
+        }
+    }
+
+    for path in writing {
+        if tokio::fs::remove_file(&path).await.is_ok() {
+            said.push(format!(
+                "swept {}, left by a dump that was killed",
+                shown(&path)
+            ));
+        }
+    }
+
+    // Newest first, so everything past `keep` is the oldest.
+    dumps.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut dropped = 0;
+    for (_, path) in dumps.into_iter().skip(keep) {
+        if tokio::fs::remove_file(&path).await.is_ok() {
+            dropped += 1;
+        }
+    }
+    if dropped > 0 {
+        said.push(format!("removed {dropped} older dump(s), keeping {keep}"));
+    }
+    said
+}
+
+fn shown(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// What to say when `pg_dump` did not finish.
+///
+/// 137 is SIGKILL, which inside a container is almost always the OOM killer —
+/// and the stderr in that case is empty or cut mid-sentence, which is the
+/// least informative failure this can produce. Naming it is the difference
+/// between a number and something to act on.
+fn dump_failure(code: i64, stderr: &str) -> String {
+    let said = stderr.trim();
+    if code == 137 {
+        return format!(
+            "the database dump ran out of memory and was killed{}",
+            if said.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", clip(said, 2000))
+            }
+        );
+    }
+    format!("pg_dump exited {code}: {}", clip(said, 2000))
+}
+
+/// Keep the head and the tail of something too long to show.
+///
+/// The middle, not the end: a Postgres failure puts `ERROR:` at the top and
+/// `HINT:` at the bottom, and a `LOCK TABLE` naming every table in the
+/// database in between. Truncating from one end loses one of the two things
+/// worth reading.
+fn clip(text: &str, keep: usize) -> String {
+    if text.len() <= keep {
+        return text.to_string();
+    }
+    let half = keep / 2;
+    let head = floor_char_boundary(text, half);
+    let tail = ceil_char_boundary(text, text.len() - half);
+    format!(
+        "{}\n… {} bytes not shown …\n{}",
+        &text[..head],
+        tail - head,
+        &text[tail..]
+    )
+}
+
+fn floor_char_boundary(s: &str, mut i: usize) -> usize {
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+fn ceil_char_boundary(s: &str, mut i: usize) -> usize {
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
 fn short(id: &str) -> String {
     let hex = id.rsplit(':').next().unwrap_or(id);
     hex.chars().take(12).collect()
@@ -658,6 +846,130 @@ fn human(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// Set a file's modified time, which is what `prune` orders by.
+    fn touch(path: &std::path::Path, when: std::time::SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(when)
+            .unwrap();
+    }
+
+    /// The two failures a whole-database dump met: one `LOCK TABLE` naming
+    /// every table, and the object graph behind it. Both scale with what is
+    /// dumped, and `-n public` is what decides that.
+    #[test]
+    fn the_dump_asks_only_for_the_schema_firetower_owns() {
+        // The command as `backup` builds it, kept in one place so this cannot
+        // drift from it silently.
+        let command = "pg_dump -U \"${POSTGRES_USER:-firetower}\" -d \"${POSTGRES_DB:-firetower}\" -n public -Fc";
+        assert!(command.contains(" -n public "), "{command}");
+        assert!(command.contains("-Fc"), "already compressed: {command}");
+        assert!(
+            !command.contains("pg_dumpall"),
+            "that would carry every schema, which is the opposite: {command}"
+        );
+    }
+
+    #[test]
+    fn a_killed_dump_says_it_ran_out_of_memory() {
+        let said = dump_failure(137, "");
+        assert!(said.contains("ran out of memory"), "{said}");
+        // Not just the number, which is what it used to be.
+        assert!(!said.contains("exited 137"), "{said}");
+    }
+
+    #[test]
+    fn any_other_failure_keeps_its_code_and_its_text() {
+        let said = dump_failure(1, "FATAL: role \"nobody\" does not exist");
+        assert!(said.contains("exited 1"), "{said}");
+        assert!(said.contains("role"), "{said}");
+    }
+
+    /// A Postgres failure puts `ERROR:` at the top and `HINT:` at the bottom,
+    /// with the statement in between. Cutting from one end loses one of them.
+    #[test]
+    fn a_long_failure_keeps_both_ends() {
+        let text = format!(
+            "ERROR: out of shared memory\n{}\nHINT: max_locks",
+            "x".repeat(200_000)
+        );
+        let kept = clip(&text, 2000);
+        assert!(kept.len() < 3000, "{} bytes", kept.len());
+        assert!(kept.starts_with("ERROR: out of shared memory"), "{kept}");
+        assert!(kept.ends_with("HINT: max_locks"), "{kept}");
+        assert!(
+            kept.contains("not shown"),
+            "it says what it dropped: {kept}"
+        );
+    }
+
+    #[test]
+    fn something_short_is_left_alone() {
+        assert_eq!(clip("ERROR: nope", 2000), "ERROR: nope");
+    }
+
+    #[tokio::test]
+    async fn pruning_keeps_the_newest_and_drops_the_rest() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut made = Vec::new();
+        for n in 0..6 {
+            let path = dir
+                .path()
+                .join(format!("firetower-0.{n}.0-2026010{n}T000000Z.dump"));
+            std::fs::write(&path, "x").unwrap();
+            // Distinct mtimes, oldest first.
+            let when =
+                std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000 + n * 60);
+            touch(&path, when);
+            made.push(path);
+        }
+
+        prune(dir.path(), 3).await;
+
+        let left: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(left.len(), 3, "{left:?}");
+        for path in &made[3..] {
+            assert!(path.exists(), "the newest three stay: {}", path.display());
+        }
+        for path in &made[..3] {
+            assert!(!path.exists(), "the oldest three go: {}", path.display());
+        }
+    }
+
+    /// Somebody's server, and a directory this did not create everything in.
+    #[tokio::test]
+    async fn pruning_touches_nothing_that_is_not_ours() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["notes.txt", "firetower.env", "someone-elses.dump", "README"] {
+            std::fs::write(dir.path().join(name), "x").unwrap();
+        }
+        prune(dir.path(), 0).await;
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 4);
+    }
+
+    /// What an out-of-memory dump leaves: the failure path deletes its own
+    /// temporary, and a killed process never reaches it.
+    #[tokio::test]
+    async fn the_remains_of_a_killed_dump_are_swept_once_they_are_old() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = dir.path().join("firetower-0.32.0-x.dump.writing");
+        let fresh = dir.path().join("firetower-0.33.0-y.dump.writing");
+        std::fs::write(&old, "x").unwrap();
+        std::fs::write(&fresh, "x").unwrap();
+        let two_days = std::time::SystemTime::now() - Duration::from_secs(48 * 60 * 60);
+        touch(&old, two_days);
+
+        prune(dir.path(), 10).await;
+
+        assert!(!old.exists(), "an old one is swept");
+        assert!(fresh.exists(), "a dump in progress is not");
+    }
+
     use super::*;
 
     #[test]

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -77,6 +77,49 @@ went, and carries on with the workers.
 Every ssh key materialisation for an upgrade is a line in the vault's access
 log, with the run and the machine as its reason.
 
+## Backups
+
+An upgrade of the control plane takes a `pg_dump` into `backups/` beside the
+compose file first. It dumps `public` — the schema every migration writes to
+and the only one a restore needs — and keeps the ten most recent, deleting
+older ones after each new dump lands.
+
+**Back up now**, on the Updates screen, runs the same thing without upgrading.
+Worth pressing once after a deployment changes: until it existed, the only way
+to find out a backup was broken was to try to upgrade.
+
+### When the backup fails
+
+The run stops and asks. Nothing has been upgraded at that point, and the screen
+offers **Upgrade without a backup** or **Cancel** — an upgrade with no way back
+is a decision, not something a failed step gets to make. The step stays in the
+run's history as a warning, so it says later that the upgrade went ahead
+without one.
+
+### Schemas Firetower did not create
+
+The backup counts the schemas in the database first and says so when there are
+any that are not `public`. The usual cause is the test suite having been
+pointed at that database: it makes a schema per test, and the sweeper that
+removes them only exists in a test build, so nothing in a release ever cleans
+one up.
+
+They are harmless to the control plane and skipped by the backup. To clear
+them, with the compose project's database container:
+
+```sh
+docker exec -i firetower-postgres-1 psql -U firetower -d firetower <<'SQL'
+SELECT format('DROP SCHEMA %I CASCADE;', schema_name)
+FROM information_schema.schemata
+WHERE schema_name LIKE 'test\_%'
+\gexec
+SQL
+```
+
+`\gexec` runs each `DROP` as its own statement. Do not wrap them in one
+transaction — a thousand drops together exhaust `max_locks_per_transaction`
+and fail having done nothing.
+
 ## Environment
 
 | Variable | Where | Meaning |

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -99,13 +99,17 @@ without one.
 ### Schemas Firetower did not create
 
 The backup counts the schemas in the database first and says so when there are
-any that are not `public`. The usual cause is the test suite having been
-pointed at that database: it makes a schema per test, and the sweeper that
-removes them only exists in a test build, so nothing in a release ever cleans
-one up.
+any that are not `public`. Everything Firetower has is in `public`, so the
+usual cause is something else sharing the Postgres instance — which is fine,
+and which the backup skips.
 
-They are harmless to the control plane and skipped by the backup. To clear
-them, with the compose project's database container:
+They are harmless to the control plane. What they do affect is `pg_dump`: it
+locks everything it dumps in one statement, so a database with enough of them
+in it could not be dumped at all before the backup was narrowed to `public`.
+
+To clear schemas that should not be there, with the compose project's database
+container — the pattern below matches the ones a Firetower checkout's test
+suite leaves, so change it to match yours:
 
 ```sh
 docker exec -i firetower-postgres-1 psql -U firetower -d firetower <<'SQL'

--- a/migrations/server/20260912140000_waiting_decision.sql
+++ b/migrations/server/20260912140000_waiting_decision.sql
@@ -1,0 +1,13 @@
+-- A run can stop and wait for somebody to answer.
+--
+-- The backup step used to end the run when it failed, which left no way to
+-- upgrade a deployment whose database could not be dumped. It now warns and
+-- waits, and this state is what it waits in.
+--
+-- No constraint on the column to widen — both state columns are plain text.
+-- What has to change is the index the "is anything running" query rides on,
+-- and a partial index cannot be altered in place.
+drop index if exists update_runs_active;
+
+create index update_runs_active on update_runs (created_at desc)
+    where state in ('planned', 'waiting_idle', 'running', 'waiting_decision');

--- a/web/components/UpdateRun.tsx
+++ b/web/components/UpdateRun.tsx
@@ -6,12 +6,20 @@ import {
   getGetUpdatesQueryKey,
   getListRunsQueryKey,
   useCancelRun,
+  useContinueRun,
   useGetRun,
 } from "@/src/api/generated/updates/updates";
 import type { UpdateRun, UpdateStep } from "@/src/api/generated/model";
 import { Badge, Button } from "@/components/ui";
 import { ApiError } from "@/src/api/http";
-import { duration, isActive, RUN_LABEL, runTone, stepGlyph } from "@/src/api/updates";
+import {
+  duration,
+  isActive,
+  needsAnAnswer,
+  RUN_LABEL,
+  runTone,
+  stepGlyph,
+} from "@/src/api/updates";
 
 /**
  * One upgrade, as it happens and afterwards.
@@ -36,6 +44,7 @@ export function RunView({ id, onDone }: { id: string; onDone?: () => void }) {
   });
 
   const cancel = useCancelRun();
+  const carryOn = useContinueRun();
   const refresh = () => {
     queryClient.invalidateQueries({ queryKey: getGetUpdatesQueryKey() });
     queryClient.invalidateQueries({ queryKey: getListRunsQueryKey() });
@@ -53,7 +62,11 @@ export function RunView({ id, onDone }: { id: string; onDone?: () => void }) {
   }
 
   const active = isActive(run);
-  const canCancel = run.state === "planned" || run.state === "waitingIdle";
+  const waiting = needsAnAnswer(run);
+  const canCancel = run.state === "planned" || run.state === "waitingIdle" || waiting;
+  // The step that stopped it, so the panel below can say what went wrong in
+  // its own words rather than repeating a summary.
+  const warned = run.steps.find((s) => s.state === "warned");
 
   return (
     <div className="panel">
@@ -96,6 +109,44 @@ export function RunView({ id, onDone }: { id: string; onDone?: () => void }) {
           </Button>
         )}
       </div>
+
+      {/* A run that stopped to ask. Nothing happens until somebody answers —
+          an upgrade with no backup is a decision, not a default. */}
+      {waiting && (
+        <div className="border-b border-brick-deep bg-brick-tint px-4 py-3">
+          <p className="text-ui text-bone">The backup didn&apos;t work.</p>
+          {warned?.detail && (
+            <pre className="mt-2 max-h-40 overflow-auto rounded-sm bg-black/25 px-3 py-2 font-mono text-meta leading-[1.6] whitespace-pre-wrap text-mute">
+              {warned.detail}
+            </pre>
+          )}
+          <p className="mt-2 text-meta leading-[1.5] text-mute">
+            Nothing has been upgraded yet. Carrying on means upgrading with no backup of the
+            database to go back to.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              disabled={carryOn.isPending}
+              onClick={() =>
+                carryOn.mutate(
+                  { id: run.id },
+                  {
+                    onSuccess: () => {
+                      setProblem(null);
+                      refresh();
+                    },
+                    onError: (e) =>
+                      setProblem(e instanceof ApiError ? e.message : "That didn't work."),
+                  },
+                )
+              }
+            >
+              Upgrade without a backup
+            </Button>
+          </div>
+        </div>
+      )}
 
       {problem && <p className="px-4 pt-3 text-meta text-brick">{problem}</p>}
       {run.error && !active && <p className="px-4 pt-3 text-meta text-brick">{run.error}</p>}

--- a/web/components/Updates.tsx
+++ b/web/components/Updates.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ArrowUpRight, CircleFadingArrowUp, RefreshCw } from "lucide-react";
 import {
   getGetUpdatesQueryKey,
+  useBackUpNow,
   useCheckUpdates,
   useGetUpdates,
   useListRuns,
@@ -189,6 +190,8 @@ export function UpdatesScreen() {
         </Empty>
       )}
 
+      {status?.controlPlane.updater.reachable && !active && <BackUpRow />}
+
       {status && !active && <CliRow status={status} />}
 
       {runs.length > 0 && (
@@ -351,5 +354,42 @@ function CliRow({ status }: { status: UpdateStatus }) {
       lives on your own machine, so it is yours to run:{" "}
       <span className="font-mono text-text">npm i -g @firetower/cli</span>
     </p>
+  );
+}
+
+/**
+ * Take a backup without upgrading.
+ *
+ * A backup only ever ran inside an upgrade, so the only way to find out it was
+ * broken was to try to upgrade — which is how one got found, on a database
+ * `pg_dump` could not read.
+ */
+function BackUpRow() {
+  const backUp = useBackUpNow();
+  const [said, setSaid] = useState<string | null>(null);
+
+  return (
+    <div className="panel mt-4 flex flex-wrap items-center gap-3 px-5 py-4">
+      <div className="min-w-0 flex-1">
+        <p className="text-ui text-bone">Back up the database</p>
+        <p className="mt-1 text-meta leading-[1.5] text-mute">
+          An upgrade takes one first. This runs the same thing on its own, so a backup that
+          cannot be taken is something you find out about now.
+        </p>
+        {said && <p className="mt-2 text-meta text-dim">{said}</p>}
+      </div>
+      <Button
+        size="sm"
+        disabled={backUp.isPending}
+        onClick={() =>
+          backUp.mutate(undefined, {
+            onSuccess: (id) => setSaid(`Started. Updater job ${id}.`),
+            onError: (e) => setSaid(e instanceof ApiError ? e.message : "That didn't work."),
+          })
+        }
+      >
+        {backUp.isPending ? "Backing up…" : "Back up now"}
+      </Button>
+    </div>
   );
 }

--- a/web/src/api/generated/accounts/accounts.ts
+++ b/web/src/api/generated/accounts/accounts.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/accounts/accounts.zod.ts
+++ b/web/src/api/generated/accounts/accounts.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/agents/agents.ts
+++ b/web/src/api/generated/agents/agents.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/agents/agents.zod.ts
+++ b/web/src/api/generated/agents/agents.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/auth/auth.ts
+++ b/web/src/api/generated/auth/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/auth/auth.zod.ts
+++ b/web/src/api/generated/auth/auth.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/conversation/conversation.ts
+++ b/web/src/api/generated/conversation/conversation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/conversation/conversation.zod.ts
+++ b/web/src/api/generated/conversation/conversation.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/events/events.ts
+++ b/web/src/api/generated/events/events.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useQuery,

--- a/web/src/api/generated/events/events.zod.ts
+++ b/web/src/api/generated/events/events.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/hosts/hosts.ts
+++ b/web/src/api/generated/hosts/hosts.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/hosts/hosts.zod.ts
+++ b/web/src/api/generated/hosts/hosts.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/meta/meta.ts
+++ b/web/src/api/generated/meta/meta.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useQuery,

--- a/web/src/api/generated/meta/meta.zod.ts
+++ b/web/src/api/generated/meta/meta.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/model/accessEntry.ts
+++ b/web/src/api/generated/model/accessEntry.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/account.ts
+++ b/web/src/api/generated/model/account.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Limit } from './limit';
 

--- a/web/src/api/generated/model/agent.ts
+++ b/web/src/api/generated/model/agent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/agentMode.ts
+++ b/web/src/api/generated/model/agentMode.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/agentOnHost.ts
+++ b/web/src/api/generated/model/agentOnHost.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface AgentOnHost {

--- a/web/src/api/generated/model/agentPresence.ts
+++ b/web/src/api/generated/model/agentPresence.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 

--- a/web/src/api/generated/model/agentView.ts
+++ b/web/src/api/generated/model/agentView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 import type { AgentMode } from './agentMode';

--- a/web/src/api/generated/model/annotationSelection.ts
+++ b/web/src/api/generated/model/annotationSelection.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { AnnotationVersion } from './annotationVersion';
 

--- a/web/src/api/generated/model/annotationVersion.ts
+++ b/web/src/api/generated/model/annotationVersion.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface AnnotationVersion {

--- a/web/src/api/generated/model/answer.ts
+++ b/web/src/api/generated/model/answer.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Decision } from './decision';
 

--- a/web/src/api/generated/model/apiError.ts
+++ b/web/src/api/generated/model/apiError.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ErrorCode } from './errorCode';
 

--- a/web/src/api/generated/model/attached.ts
+++ b/web/src/api/generated/model/attached.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/attachment.ts
+++ b/web/src/api/generated/model/attachment.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/auth.ts
+++ b/web/src/api/generated/model/auth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/bootstrap.ts
+++ b/web/src/api/generated/model/bootstrap.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/branches.ts
+++ b/web/src/api/generated/model/branches.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Branches {

--- a/web/src/api/generated/model/capacity.ts
+++ b/web/src/api/generated/model/capacity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/cause.ts
+++ b/web/src/api/generated/model/cause.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/changedWhat.ts
+++ b/web/src/api/generated/model/changedWhat.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/checkout.ts
+++ b/web/src/api/generated/model/checkout.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { PullState } from './pullState';
 import type { RepoId } from './repoId';

--- a/web/src/api/generated/model/checkoutSummary.ts
+++ b/web/src/api/generated/model/checkoutSummary.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { WorkSummary } from './workSummary';
 

--- a/web/src/api/generated/model/checkoutWork.ts
+++ b/web/src/api/generated/model/checkoutWork.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { PullState } from './pullState';
 

--- a/web/src/api/generated/model/choice.ts
+++ b/web/src/api/generated/model/choice.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/chosen.ts
+++ b/web/src/api/generated/model/chosen.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ControlKind } from './controlKind';
 

--- a/web/src/api/generated/model/clientFrame.ts
+++ b/web/src/api/generated/model/clientFrame.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Topic } from './topic';
 

--- a/web/src/api/generated/model/clientId.ts
+++ b/web/src/api/generated/model/clientId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/commit.ts
+++ b/web/src/api/generated/model/commit.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Commit {

--- a/web/src/api/generated/model/compute.ts
+++ b/web/src/api/generated/model/compute.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { SshKey } from './sshKey';
 

--- a/web/src/api/generated/model/configureAgent.ts
+++ b/web/src/api/generated/model/configureAgent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { AgentMode } from './agentMode';
 

--- a/web/src/api/generated/model/connected.ts
+++ b/web/src/api/generated/model/connected.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/control.ts
+++ b/web/src/api/generated/model/control.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Choice } from './choice';
 import type { ControlKind } from './controlKind';

--- a/web/src/api/generated/model/controlKind.ts
+++ b/web/src/api/generated/model/controlKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/controlPlaneTarget.ts
+++ b/web/src/api/generated/model/controlPlaneTarget.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { UpdaterView } from './updaterView';
 

--- a/web/src/api/generated/model/conversation.ts
+++ b/web/src/api/generated/model/conversation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ConversationEvent } from './conversationEvent';
 

--- a/web/src/api/generated/model/conversationEvent.ts
+++ b/web/src/api/generated/model/conversationEvent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { TurnEvent } from './turnEvent';
 

--- a/web/src/api/generated/model/createAccount.ts
+++ b/web/src/api/generated/model/createAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 import type { AgentMode } from './agentMode';

--- a/web/src/api/generated/model/credentials.ts
+++ b/web/src/api/generated/model/credentials.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Credentials {

--- a/web/src/api/generated/model/decision.ts
+++ b/web/src/api/generated/model/decision.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/deleteHostParams.ts
+++ b/web/src/api/generated/model/deleteHostParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type DeleteHostParams = {

--- a/web/src/api/generated/model/destroySessionParams.ts
+++ b/web/src/api/generated/model/destroySessionParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type DestroySessionParams = {

--- a/web/src/api/generated/model/diagnosis.ts
+++ b/web/src/api/generated/model/diagnosis.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Cause } from './cause';
 

--- a/web/src/api/generated/model/dockerState.ts
+++ b/web/src/api/generated/model/dockerState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { DockerStatus } from './dockerStatus';
 

--- a/web/src/api/generated/model/dockerStatus.ts
+++ b/web/src/api/generated/model/dockerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/done.ts
+++ b/web/src/api/generated/model/done.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Done {

--- a/web/src/api/generated/model/downloadFileParams.ts
+++ b/web/src/api/generated/model/downloadFileParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type DownloadFileParams = {

--- a/web/src/api/generated/model/drain.ts
+++ b/web/src/api/generated/model/drain.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Drain {

--- a/web/src/api/generated/model/elementSnapshot.ts
+++ b/web/src/api/generated/model/elementSnapshot.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface ElementSnapshot {

--- a/web/src/api/generated/model/endAll.ts
+++ b/web/src/api/generated/model/endAll.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/endedAll.ts
+++ b/web/src/api/generated/model/endedAll.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface EndedAll {

--- a/web/src/api/generated/model/envVariable.ts
+++ b/web/src/api/generated/model/envVariable.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface EnvVariable {

--- a/web/src/api/generated/model/errorCode.ts
+++ b/web/src/api/generated/model/errorCode.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/event.ts
+++ b/web/src/api/generated/model/event.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { EventKind } from './eventKind';
 import type { SessionId } from './sessionId';

--- a/web/src/api/generated/model/eventKind.ts
+++ b/web/src/api/generated/model/eventKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 import type { SessionStatus } from './sessionStatus';

--- a/web/src/api/generated/model/execution.ts
+++ b/web/src/api/generated/model/execution.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type Execution = typeof Execution[keyof typeof Execution];

--- a/web/src/api/generated/model/fallback.ts
+++ b/web/src/api/generated/model/fallback.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Fallback {

--- a/web/src/api/generated/model/fileChoice.ts
+++ b/web/src/api/generated/model/fileChoice.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface FileChoice {

--- a/web/src/api/generated/model/fileDiff.ts
+++ b/web/src/api/generated/model/fileDiff.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/fileEntry.ts
+++ b/web/src/api/generated/model/fileEntry.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/filePlan.ts
+++ b/web/src/api/generated/model/filePlan.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { FileVerdict } from './fileVerdict';
 

--- a/web/src/api/generated/model/fileVerdict.ts
+++ b/web/src/api/generated/model/fileVerdict.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type FileVerdict = typeof FileVerdict[keyof typeof FileVerdict];

--- a/web/src/api/generated/model/findFilesParams.ts
+++ b/web/src/api/generated/model/findFilesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type FindFilesParams = {

--- a/web/src/api/generated/model/forwarded.ts
+++ b/web/src/api/generated/model/forwarded.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/getConversationParams.ts
+++ b/web/src/api/generated/model/getConversationParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type GetConversationParams = {

--- a/web/src/api/generated/model/getTaskParams.ts
+++ b/web/src/api/generated/model/getTaskParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type GetTaskParams = {

--- a/web/src/api/generated/model/gitIdentity.ts
+++ b/web/src/api/generated/model/gitIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/heldSecret.ts
+++ b/web/src/api/generated/model/heldSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/host.ts
+++ b/web/src/api/generated/model/host.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Capacity } from './capacity';
 import type { Compute } from './compute';

--- a/web/src/api/generated/model/hostId.ts
+++ b/web/src/api/generated/model/hostId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/hostReadinessParams.ts
+++ b/web/src/api/generated/model/hostReadinessParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 

--- a/web/src/api/generated/model/hostState.ts
+++ b/web/src/api/generated/model/hostState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type HostState = typeof HostState[keyof typeof HostState];

--- a/web/src/api/generated/model/hostTarget.ts
+++ b/web/src/api/generated/model/hostTarget.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { TargetKind } from './targetKind';
 

--- a/web/src/api/generated/model/index.ts
+++ b/web/src/api/generated/model/index.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export * from './accessEntry';

--- a/web/src/api/generated/model/installAgent.ts
+++ b/web/src/api/generated/model/installAgent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/installed.ts
+++ b/web/src/api/generated/model/installed.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/itemId.ts
+++ b/web/src/api/generated/model/itemId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/itemKind.ts
+++ b/web/src/api/generated/model/itemKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/itemStatus.ts
+++ b/web/src/api/generated/model/itemStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/keepAnnotation.ts
+++ b/web/src/api/generated/model/keepAnnotation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ElementSnapshot } from './elementSnapshot';
 

--- a/web/src/api/generated/model/label.ts
+++ b/web/src/api/generated/model/label.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Label {

--- a/web/src/api/generated/model/limit.ts
+++ b/web/src/api/generated/model/limit.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Limit {

--- a/web/src/api/generated/model/listEventsParams.ts
+++ b/web/src/api/generated/model/listEventsParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type ListEventsParams = {

--- a/web/src/api/generated/model/listFilesParams.ts
+++ b/web/src/api/generated/model/listFilesParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type ListFilesParams = {

--- a/web/src/api/generated/model/listSessionsParams.ts
+++ b/web/src/api/generated/model/listSessionsParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type ListSessionsParams = {

--- a/web/src/api/generated/model/listTasksParams.ts
+++ b/web/src/api/generated/model/listTasksParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { TaskKind } from './taskKind';
 import type { TaskState } from './taskState';

--- a/web/src/api/generated/model/me.ts
+++ b/web/src/api/generated/model/me.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Organization } from './organization';
 import type { User } from './user';

--- a/web/src/api/generated/model/modelUsage.ts
+++ b/web/src/api/generated/model/modelUsage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/nameOrganization.ts
+++ b/web/src/api/generated/model/nameOrganization.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface NameOrganization {

--- a/web/src/api/generated/model/newCheckout.ts
+++ b/web/src/api/generated/model/newCheckout.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { RepoId } from './repoId';
 

--- a/web/src/api/generated/model/newEnv.ts
+++ b/web/src/api/generated/model/newEnv.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { EnvVariable } from './envVariable';
 

--- a/web/src/api/generated/model/newForward.ts
+++ b/web/src/api/generated/model/newForward.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface NewForward {

--- a/web/src/api/generated/model/newHost.ts
+++ b/web/src/api/generated/model/newHost.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Compute } from './compute';
 

--- a/web/src/api/generated/model/newPassword.ts
+++ b/web/src/api/generated/model/newPassword.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface NewPassword {

--- a/web/src/api/generated/model/newPullRequest.ts
+++ b/web/src/api/generated/model/newPullRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface NewPullRequest {

--- a/web/src/api/generated/model/newRepo.ts
+++ b/web/src/api/generated/model/newRepo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/newRun.ts
+++ b/web/src/api/generated/model/newRun.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { FileChoice } from './fileChoice';
 

--- a/web/src/api/generated/model/newSession.ts
+++ b/web/src/api/generated/model/newSession.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 import type { HostId } from './hostId';

--- a/web/src/api/generated/model/orgId.ts
+++ b/web/src/api/generated/model/orgId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/organization.ts
+++ b/web/src/api/generated/model/organization.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { OrgId } from './orgId';
 

--- a/web/src/api/generated/model/page.ts
+++ b/web/src/api/generated/model/page.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Task } from './task';
 

--- a/web/src/api/generated/model/pendingAuth.ts
+++ b/web/src/api/generated/model/pendingAuth.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/person.ts
+++ b/web/src/api/generated/model/person.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Person {

--- a/web/src/api/generated/model/placed.ts
+++ b/web/src/api/generated/model/placed.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Placed {

--- a/web/src/api/generated/model/planRequest.ts
+++ b/web/src/api/generated/model/planRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface PlanRequest {

--- a/web/src/api/generated/model/planStep.ts
+++ b/web/src/api/generated/model/planStep.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { PlanStepStatus } from './planStepStatus';
 

--- a/web/src/api/generated/model/planStepStatus.ts
+++ b/web/src/api/generated/model/planStepStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type PlanStepStatus = typeof PlanStepStatus[keyof typeof PlanStepStatus];

--- a/web/src/api/generated/model/ports.ts
+++ b/web/src/api/generated/model/ports.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Forwarded } from './forwarded';
 

--- a/web/src/api/generated/model/previewAddress.ts
+++ b/web/src/api/generated/model/previewAddress.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/previewAddressParams.ts
+++ b/web/src/api/generated/model/previewAddressParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type PreviewAddressParams = {

--- a/web/src/api/generated/model/previewAnnotation.ts
+++ b/web/src/api/generated/model/previewAnnotation.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ElementSnapshot } from './elementSnapshot';
 

--- a/web/src/api/generated/model/probeRequest.ts
+++ b/web/src/api/generated/model/probeRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface ProbeRequest {

--- a/web/src/api/generated/model/probeResponse.ts
+++ b/web/src/api/generated/model/probeResponse.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/proposal.ts
+++ b/web/src/api/generated/model/proposal.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Proposal {

--- a/web/src/api/generated/model/providerStatus.ts
+++ b/web/src/api/generated/model/providerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { PendingAuth } from './pendingAuth';
 

--- a/web/src/api/generated/model/publicIdentity.ts
+++ b/web/src/api/generated/model/publicIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/pullRequest.ts
+++ b/web/src/api/generated/model/pullRequest.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface PullRequest {

--- a/web/src/api/generated/model/pullState.ts
+++ b/web/src/api/generated/model/pullState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/question.ts
+++ b/web/src/api/generated/model/question.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { QuestionOption } from './questionOption';
 

--- a/web/src/api/generated/model/questionOption.ts
+++ b/web/src/api/generated/model/questionOption.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/rawSource.ts
+++ b/web/src/api/generated/model/rawSource.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/reached.ts
+++ b/web/src/api/generated/model/reached.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Diagnosis } from './diagnosis';
 

--- a/web/src/api/generated/model/readiness.ts
+++ b/web/src/api/generated/model/readiness.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Requirement } from './requirement';
 

--- a/web/src/api/generated/model/release.ts
+++ b/web/src/api/generated/model/release.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/remoteRepo.ts
+++ b/web/src/api/generated/model/remoteRepo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/rename.ts
+++ b/web/src/api/generated/model/rename.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Rename {

--- a/web/src/api/generated/model/renameSession.ts
+++ b/web/src/api/generated/model/renameSession.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface RenameSession {

--- a/web/src/api/generated/model/replaceSecret.ts
+++ b/web/src/api/generated/model/replaceSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface ReplaceSecret {

--- a/web/src/api/generated/model/repo.ts
+++ b/web/src/api/generated/model/repo.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { RepoId } from './repoId';
 

--- a/web/src/api/generated/model/repoChanges.ts
+++ b/web/src/api/generated/model/repoChanges.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/repoId.ts
+++ b/web/src/api/generated/model/repoId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/requestId.ts
+++ b/web/src/api/generated/model/requestId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/requestKind.ts
+++ b/web/src/api/generated/model/requestKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/requirement.ts
+++ b/web/src/api/generated/model/requirement.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Requirement {

--- a/web/src/api/generated/model/revealedSecret.ts
+++ b/web/src/api/generated/model/revealedSecret.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/rotated.ts
+++ b/web/src/api/generated/model/rotated.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/runState.ts
+++ b/web/src/api/generated/model/runState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type RunState = typeof RunState[keyof typeof RunState];
@@ -12,6 +12,7 @@ export type RunState = typeof RunState[keyof typeof RunState];
 export const RunState = {
   planned: 'planned',
   waitingIdle: 'waitingIdle',
+  waitingDecision: 'waitingDecision',
   running: 'running',
   succeeded: 'succeeded',
   failed: 'failed',

--- a/web/src/api/generated/model/scopeKind.ts
+++ b/web/src/api/generated/model/scopeKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/sent.ts
+++ b/web/src/api/generated/model/sent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Sent {

--- a/web/src/api/generated/model/serverFrame.ts
+++ b/web/src/api/generated/model/serverFrame.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { EventKind } from './eventKind';
 import type { SessionId } from './sessionId';

--- a/web/src/api/generated/model/session.ts
+++ b/web/src/api/generated/model/session.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Agent } from './agent';
 import type { Checkout } from './checkout';

--- a/web/src/api/generated/model/sessionAccount.ts
+++ b/web/src/api/generated/model/sessionAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Account } from './account';
 import type { Limit } from './limit';

--- a/web/src/api/generated/model/sessionDiffParams.ts
+++ b/web/src/api/generated/model/sessionDiffParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type SessionDiffParams = {

--- a/web/src/api/generated/model/sessionId.ts
+++ b/web/src/api/generated/model/sessionId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/sessionPtyParams.ts
+++ b/web/src/api/generated/model/sessionPtyParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type SessionPtyParams = {

--- a/web/src/api/generated/model/sessionStatus.ts
+++ b/web/src/api/generated/model/sessionStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type SessionStatus = typeof SessionStatus[keyof typeof SessionStatus];

--- a/web/src/api/generated/model/setIdentity.ts
+++ b/web/src/api/generated/model/setIdentity.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/setShare.ts
+++ b/web/src/api/generated/model/setShare.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Share } from './share';
 

--- a/web/src/api/generated/model/setupState.ts
+++ b/web/src/api/generated/model/setupState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Organization } from './organization';
 

--- a/web/src/api/generated/model/share.ts
+++ b/web/src/api/generated/model/share.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/signIn.ts
+++ b/web/src/api/generated/model/signIn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/signedIn.ts
+++ b/web/src/api/generated/model/signedIn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { User } from './user';
 

--- a/web/src/api/generated/model/slashCommand.ts
+++ b/web/src/api/generated/model/slashCommand.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/sshKey.ts
+++ b/web/src/api/generated/model/sshKey.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/step.ts
+++ b/web/src/api/generated/model/step.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/stepState.ts
+++ b/web/src/api/generated/model/stepState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type StepState = typeof StepState[keyof typeof StepState];
@@ -14,5 +14,6 @@ export const StepState = {
   running: 'running',
   done: 'done',
   failed: 'failed',
+  warned: 'warned',
   skipped: 'skipped',
 } as const;

--- a/web/src/api/generated/model/storedEnv.ts
+++ b/web/src/api/generated/model/storedEnv.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/streamKind.ts
+++ b/web/src/api/generated/model/streamKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/switch.ts
+++ b/web/src/api/generated/model/switch.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Switch {

--- a/web/src/api/generated/model/switchAccount.ts
+++ b/web/src/api/generated/model/switchAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface SwitchAccount {

--- a/web/src/api/generated/model/switchedAccount.ts
+++ b/web/src/api/generated/model/switchedAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface SwitchedAccount {

--- a/web/src/api/generated/model/targetKind.ts
+++ b/web/src/api/generated/model/targetKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type TargetKind = typeof TargetKind[keyof typeof TargetKind];

--- a/web/src/api/generated/model/targets.ts
+++ b/web/src/api/generated/model/targets.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface Targets {

--- a/web/src/api/generated/model/task.ts
+++ b/web/src/api/generated/model/task.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Label } from './label';
 import type { Person } from './person';

--- a/web/src/api/generated/model/taskId.ts
+++ b/web/src/api/generated/model/taskId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/taskKind.ts
+++ b/web/src/api/generated/model/taskKind.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/taskScope.ts
+++ b/web/src/api/generated/model/taskScope.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/taskState.ts
+++ b/web/src/api/generated/model/taskState.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type TaskState = typeof TaskState[keyof typeof TaskState];

--- a/web/src/api/generated/model/topic.ts
+++ b/web/src/api/generated/model/topic.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/trackerKey.ts
+++ b/web/src/api/generated/model/trackerKey.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface TrackerKey {

--- a/web/src/api/generated/model/trackerStatus.ts
+++ b/web/src/api/generated/model/trackerStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Auth } from './auth';
 import type { ScopeKind } from './scopeKind';

--- a/web/src/api/generated/model/turn.ts
+++ b/web/src/api/generated/model/turn.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Attached } from './attached';
 

--- a/web/src/api/generated/model/turnEvent.ts
+++ b/web/src/api/generated/model/turnEvent.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { Decision } from './decision';
 import type { ItemId } from './itemId';

--- a/web/src/api/generated/model/turnId.ts
+++ b/web/src/api/generated/model/turnId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/turnStatus.ts
+++ b/web/src/api/generated/model/turnStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/updateAccount.ts
+++ b/web/src/api/generated/model/updateAccount.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export interface UpdateAccount {

--- a/web/src/api/generated/model/updateRun.ts
+++ b/web/src/api/generated/model/updateRun.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { RunState } from './runState';
 import type { Targets } from './targets';

--- a/web/src/api/generated/model/updateStatus.ts
+++ b/web/src/api/generated/model/updateStatus.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ControlPlaneTarget } from './controlPlaneTarget';
 import type { HostTarget } from './hostTarget';

--- a/web/src/api/generated/model/updateStep.ts
+++ b/web/src/api/generated/model/updateStep.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { StepState } from './stepState';
 

--- a/web/src/api/generated/model/updaterView.ts
+++ b/web/src/api/generated/model/updaterView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/upgradePlan.ts
+++ b/web/src/api/generated/model/upgradePlan.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { FilePlan } from './filePlan';
 

--- a/web/src/api/generated/model/usage.ts
+++ b/web/src/api/generated/model/usage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { ModelUsage } from './modelUsage';
 

--- a/web/src/api/generated/model/user.ts
+++ b/web/src/api/generated/model/user.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { OrgId } from './orgId';
 import type { UserId } from './userId';

--- a/web/src/api/generated/model/userId.ts
+++ b/web/src/api/generated/model/userId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/vaultView.ts
+++ b/web/src/api/generated/model/vaultView.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import type { AccessEntry } from './accessEntry';
 import type { HeldSecret } from './heldSecret';

--- a/web/src/api/generated/model/workSummary.ts
+++ b/web/src/api/generated/model/workSummary.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/workspaceId.ts
+++ b/web/src/api/generated/model/workspaceId.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/model/workspaceSize.ts
+++ b/web/src/api/generated/model/workspaceSize.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 export type WorkspaceSize = typeof WorkspaceSize[keyof typeof WorkspaceSize];

--- a/web/src/api/generated/model/workspaceUsage.ts
+++ b/web/src/api/generated/model/workspaceUsage.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 
 /**

--- a/web/src/api/generated/providers/providers.ts
+++ b/web/src/api/generated/providers/providers.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/providers/providers.zod.ts
+++ b/web/src/api/generated/providers/providers.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/repos/repos.ts
+++ b/web/src/api/generated/repos/repos.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/repos/repos.zod.ts
+++ b/web/src/api/generated/repos/repos.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/secrets/secrets.ts
+++ b/web/src/api/generated/secrets/secrets.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/secrets/secrets.zod.ts
+++ b/web/src/api/generated/secrets/secrets.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/sessions/sessions.ts
+++ b/web/src/api/generated/sessions/sessions.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/sessions/sessions.zod.ts
+++ b/web/src/api/generated/sessions/sessions.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/setup/setup.ts
+++ b/web/src/api/generated/setup/setup.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/setup/setup.zod.ts
+++ b/web/src/api/generated/setup/setup.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/stream/stream.ts
+++ b/web/src/api/generated/stream/stream.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useQuery,

--- a/web/src/api/generated/stream/stream.zod.ts
+++ b/web/src/api/generated/stream/stream.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/tasks/tasks.ts
+++ b/web/src/api/generated/tasks/tasks.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useQuery,

--- a/web/src/api/generated/tasks/tasks.zod.ts
+++ b/web/src/api/generated/tasks/tasks.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/trackers/trackers.ts
+++ b/web/src/api/generated/trackers/trackers.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,

--- a/web/src/api/generated/trackers/trackers.zod.ts
+++ b/web/src/api/generated/trackers/trackers.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 

--- a/web/src/api/generated/updates/updates.ts
+++ b/web/src/api/generated/updates/updates.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import {
   useMutation,
@@ -173,7 +173,80 @@ export const useGetGetUpdatesQueryData = () => {
 }
 
 
-export const getCheckUpdatesUrl = () => {
+export const getBackUpNowUrl = () => {
+
+
+
+
+  return `/api/v1/updates/backup`
+}
+
+/**
+ * Until this existed a backup only ever ran inside an upgrade, so there was
+ * no way to find out it was broken except by trying to upgrade — which is how
+ * one got found.
+ * @summary Take a backup now, outside an upgrade.
+ */
+export const backUpNow = async ( options?: Parameters<typeof http>[1]): Promise<string> => {
+
+  return http<string>(getBackUpNowUrl(),
+  {
+    ...options,
+    method: 'POST'
+
+
+  }
+);}
+
+
+
+
+
+export const getBackUpNowMutationOptions = <TError = ApiError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof backUpNow>>, TError,void, TContext>, request?: SecondParameter<typeof http>}
+): UseMutationOptions<Awaited<ReturnType<typeof backUpNow>>, TError,void, TContext> => {
+
+const mutationKey = ['backUpNow'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof backUpNow>>, void> = () => {
+
+
+          return  backUpNow(requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type BackUpNowMutationResult = NonNullable<Awaited<ReturnType<typeof backUpNow>>>
+
+    export type BackUpNowMutationError = ApiError
+
+    /**
+ * @summary Take a backup now, outside an upgrade.
+ */
+export const useBackUpNow = <TError = ApiError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof backUpNow>>, TError,void, TContext>, request?: SecondParameter<typeof http>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof backUpNow>>,
+        TError,
+        void,
+        TContext
+      > => {
+      return useMutation(getBackUpNowMutationOptions(options), queryClient);
+    }
+    export const getCheckUpdatesUrl = () => {
 
 
 
@@ -681,4 +754,77 @@ export const useCancelRun = <TError = ApiError,
         TContext
       > => {
       return useMutation(getCancelRunMutationOptions(options), queryClient);
+    }
+    export const getContinueRunUrl = (id: string,) => {
+
+
+
+
+  return `/api/v1/updates/runs/${id}/continue`
+}
+
+/**
+ * Only a run waiting on the backup reaches this, and the answer is always the
+ * same one: go ahead without a backup. Its step keeps the `Warned` state, so
+ * the history says the upgrade went ahead without one.
+ * @summary Carry on with a run that stopped to ask.
+ */
+export const continueRun = async (id: string, options?: Parameters<typeof http>[1]): Promise<UpdateRun> => {
+
+  return http<UpdateRun>(getContinueRunUrl(id),
+  {
+    ...options,
+    method: 'POST'
+
+
+  }
+);}
+
+
+
+
+
+export const getContinueRunMutationOptions = <TError = ApiError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof continueRun>>, TError,{id: string}, TContext>, request?: SecondParameter<typeof http>}
+): UseMutationOptions<Awaited<ReturnType<typeof continueRun>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['continueRun'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof continueRun>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  continueRun(id,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ContinueRunMutationResult = NonNullable<Awaited<ReturnType<typeof continueRun>>>
+
+    export type ContinueRunMutationError = ApiError
+
+    /**
+ * @summary Carry on with a run that stopped to ask.
+ */
+export const useContinueRun = <TError = ApiError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof continueRun>>, TError,{id: string}, TContext>, request?: SecondParameter<typeof http>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof continueRun>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+      return useMutation(getContinueRunMutationOptions(options), queryClient);
     }

--- a/web/src/api/generated/updates/updates.zod.ts
+++ b/web/src/api/generated/updates/updates.zod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  * Firetower
  * The Firetower control plane: API, scheduling, and worker transports.
- * OpenAPI spec version: 0.32.0
+ * OpenAPI spec version: 0.32.1
  */
 import * as zod from 'zod';
 
@@ -53,6 +53,14 @@ export const GetUpdatesResponse = zod.object({
 }).describe('The newest release, as far as the last check knows.')]).optional(),
   "updateAvailable": zod.boolean().describe('Whether anything at all is behind the newest release.')
 })
+
+/**
+ * Until this existed a backup only ever ran inside an upgrade, so there was
+ * no way to find out it was broken except by trying to upgrade — which is how
+ * one got found.
+ * @summary Take a backup now, outside an upgrade.
+ */
+export const BackUpNowResponse = zod.string()
 
 /**
  * @summary Ask the releases feed now rather than waiting for the next check.
@@ -132,14 +140,14 @@ export const ListRunsResponseItem = zod.object({
   "id": zod.string(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
   "startedBy": zod.string().nullish(),
-  "state": zod.enum(['planned', 'waitingIdle', 'running', 'succeeded', 'failed', 'cancelled']),
+  "state": zod.enum(['planned', 'waitingIdle', 'waitingDecision', 'running', 'succeeded', 'failed', 'cancelled']),
   "steps": zod.array(zod.object({
   "detail": zod.string().nullish(),
   "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
   "log": zod.string(),
   "position": zod.int(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
-  "state": zod.enum(['pending', 'running', 'done', 'failed', 'skipped']),
+  "state": zod.enum(['pending', 'running', 'done', 'failed', 'warned', 'skipped']),
   "target": zod.string(),
   "title": zod.string()
 })),
@@ -175,14 +183,14 @@ export const CreateRunResponse = zod.object({
   "id": zod.string(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
   "startedBy": zod.string().nullish(),
-  "state": zod.enum(['planned', 'waitingIdle', 'running', 'succeeded', 'failed', 'cancelled']),
+  "state": zod.enum(['planned', 'waitingIdle', 'waitingDecision', 'running', 'succeeded', 'failed', 'cancelled']),
   "steps": zod.array(zod.object({
   "detail": zod.string().nullish(),
   "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
   "log": zod.string(),
   "position": zod.int(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
-  "state": zod.enum(['pending', 'running', 'done', 'failed', 'skipped']),
+  "state": zod.enum(['pending', 'running', 'done', 'failed', 'warned', 'skipped']),
   "target": zod.string(),
   "title": zod.string()
 })),
@@ -206,14 +214,14 @@ export const GetRunResponse = zod.object({
   "id": zod.string(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
   "startedBy": zod.string().nullish(),
-  "state": zod.enum(['planned', 'waitingIdle', 'running', 'succeeded', 'failed', 'cancelled']),
+  "state": zod.enum(['planned', 'waitingIdle', 'waitingDecision', 'running', 'succeeded', 'failed', 'cancelled']),
   "steps": zod.array(zod.object({
   "detail": zod.string().nullish(),
   "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
   "log": zod.string(),
   "position": zod.int(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
-  "state": zod.enum(['pending', 'running', 'done', 'failed', 'skipped']),
+  "state": zod.enum(['pending', 'running', 'done', 'failed', 'warned', 'skipped']),
   "target": zod.string(),
   "title": zod.string()
 })),
@@ -243,14 +251,51 @@ export const CancelRunResponse = zod.object({
   "id": zod.string(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
   "startedBy": zod.string().nullish(),
-  "state": zod.enum(['planned', 'waitingIdle', 'running', 'succeeded', 'failed', 'cancelled']),
+  "state": zod.enum(['planned', 'waitingIdle', 'waitingDecision', 'running', 'succeeded', 'failed', 'cancelled']),
   "steps": zod.array(zod.object({
   "detail": zod.string().nullish(),
   "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
   "log": zod.string(),
   "position": zod.int(),
   "startedAt": zod.iso.datetime({"offset":true}).nullish(),
-  "state": zod.enum(['pending', 'running', 'done', 'failed', 'skipped']),
+  "state": zod.enum(['pending', 'running', 'done', 'failed', 'warned', 'skipped']),
+  "target": zod.string(),
+  "title": zod.string()
+})),
+  "targets": zod.object({
+  "controlPlane": zod.boolean(),
+  "hostIds": zod.array(zod.string())
+}),
+  "toVersion": zod.string(),
+  "whenIdle": zod.boolean()
+})
+
+/**
+ * Only a run waiting on the backup reaches this, and the answer is always the
+ * same one: go ahead without a backup. Its step keeps the `Warned` state, so
+ * the history says the upgrade went ahead without one.
+ * @summary Carry on with a run that stopped to ask.
+ */
+export const ContinueRunParams = zod.object({
+  "id": zod.string().describe('Run id')
+})
+
+export const ContinueRunResponse = zod.object({
+  "createdAt": zod.iso.datetime({"offset":true}),
+  "error": zod.string().nullish(),
+  "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
+  "fromVersion": zod.string(),
+  "id": zod.string(),
+  "startedAt": zod.iso.datetime({"offset":true}).nullish(),
+  "startedBy": zod.string().nullish(),
+  "state": zod.enum(['planned', 'waitingIdle', 'waitingDecision', 'running', 'succeeded', 'failed', 'cancelled']),
+  "steps": zod.array(zod.object({
+  "detail": zod.string().nullish(),
+  "finishedAt": zod.iso.datetime({"offset":true}).nullish(),
+  "log": zod.string(),
+  "position": zod.int(),
+  "startedAt": zod.iso.datetime({"offset":true}).nullish(),
+  "state": zod.enum(['pending', 'running', 'done', 'failed', 'warned', 'skipped']),
   "target": zod.string(),
   "title": zod.string()
 })),

--- a/web/src/api/updates.test.ts
+++ b/web/src/api/updates.test.ts
@@ -9,7 +9,12 @@ import {
   needsChoice,
   nothingChosen,
   runSummary,
+  isActive,
+  needsAnAnswer,
+  RUN_LABEL,
+  runTone,
   showsDot,
+  stepGlyph,
   willWrite,
   wouldEnd,
 } from "./updates";
@@ -155,5 +160,33 @@ describe("a diff on screen", () => {
   it("knows which lines are which", () => {
     const lines = diffLines("--- a\n+++ a\n@@ -1 +1 @@\n-old\n+new\n same\n");
     expect(lines.map((l) => l.kind)).toEqual(["meta", "meta", "hunk", "del", "add", "same"]);
+  });
+});
+
+describe("a run that stopped to ask", () => {
+  it("is still active, so the screen keeps showing it", () => {
+    // There is nowhere else to answer. A run that vanished from the screen
+    // would be one nobody could carry on or stop.
+    expect(isActive({ state: "waitingDecision" })).toBe(true);
+    expect(needsAnAnswer({ state: "waitingDecision" })).toBe(true);
+  });
+
+  it("is not mistaken for one that is merely running", () => {
+    expect(needsAnAnswer({ state: "running" })).toBe(false);
+    expect(needsAnAnswer({ state: "failed" })).toBe(false);
+  });
+
+  it("reads as something wanting attention rather than as progress", () => {
+    expect(runTone("waitingDecision")).toBe("brick");
+    expect(RUN_LABEL.waitingDecision).toBe("waiting for you");
+  });
+});
+
+describe("a step that did not do what it was for", () => {
+  it("is neither a tick nor a cross", () => {
+    const warned = stepGlyph("warned");
+    expect(warned).not.toBe(stepGlyph("done"));
+    expect(warned).not.toBe(stepGlyph("failed"));
+    expect(warned).not.toBe(stepGlyph("pending"));
   });
 });

--- a/web/src/api/updates.ts
+++ b/web/src/api/updates.ts
@@ -84,7 +84,7 @@ export function willWrite(file: FilePlan, replace: boolean): boolean {
   }
 }
 
-export const ACTIVE: RunState[] = ["planned", "waitingIdle", "running"];
+export const ACTIVE: RunState[] = ["planned", "waitingIdle", "waitingDecision", "running"];
 
 export const isActive = (run: { state: RunState }) => ACTIVE.includes(run.state);
 
@@ -92,6 +92,7 @@ export const isActive = (run: { state: RunState }) => ACTIVE.includes(run.state)
 export const RUN_LABEL: Record<RunState, string> = {
   planned: "starting",
   waitingIdle: "waiting for idle",
+  waitingDecision: "waiting for you",
   running: "running",
   succeeded: "succeeded",
   failed: "failed",
@@ -104,6 +105,8 @@ export function runTone(state: RunState): "sage" | "brick" | "slate" | "neutral"
       return "sage";
     case "failed":
       return "brick";
+    case "waitingDecision":
+      return "brick";
     case "running":
     case "waitingIdle":
     case "planned":
@@ -112,6 +115,9 @@ export function runTone(state: RunState): "sage" | "brick" | "slate" | "neutral"
       return "neutral";
   }
 }
+
+/** Whether this run is stopped waiting for somebody to answer. */
+export const needsAnAnswer = (run: { state: RunState }) => run.state === "waitingDecision";
 
 /** The glyph in front of a step. */
 export function stepGlyph(state: StepState): string {
@@ -122,6 +128,8 @@ export function stepGlyph(state: StepState): string {
       return "✗";
     case "running":
       return "●";
+    case "warned":
+      return "!";
     case "skipped":
       return "–";
     default:


### PR DESCRIPTION
One `pg_dump` that could not run took down the whole upgrade, reported itself as
a hundred kilobytes of schema names, and offered nothing to do about it. Six
faults, each fixed here.

## The upgrade could not get past a failed backup

`steps_for` added the backup step whenever the control plane was a target — no
condition, no setting — and `backup` bailed on a failed job, so the run ended
before the updater or the control plane were touched. **A deployment whose
database could not be dumped could not be upgraded from the screen at all.**
The CLI was the only way through.

Now the run stops and asks:

* the step ends as `Warned` rather than `Failed`, and stays that way in the
  history, so it says later that the upgrade went ahead without a backup
* the run sits in a new `WaitingDecision` state — not `is_over`, so it is still
  on the screen, which is the only place the answer can be given
* `POST /updates/runs/{id}/continue` carries on; Cancel already existed
* `resume` leaves a waiting run alone, so a restart of the control plane does
  not answer the question for you
* no `put_back` while waiting — undraining now would let work onto a machine
  about to be upgraded

Also adds **Back up now**. A backup only ever ran inside an upgrade, so the only
way to find out it was broken was to try to upgrade.

## The dump asked for the whole database

`-n public` now. That is the schema every migration writes to (`grep -rn
"CREATE SCHEMA" migrations/` is empty) and the only one a restore needs.

`pg_dump` takes `ACCESS SHARE` on everything it will dump **in a single
statement** — the `… IN ACCESS SHARE MODE` line the failure ended on. Measured
against a database carrying 115 leftover test schemas and 3,200 relations:

| | tables in the one `LOCK TABLE` | time | dump size |
|---|---|---|---|
| whole database | **2,187** | 2.02s | 17.8 MB |
| `-n public` | **27** | 0.38s | 1.8 MB |

Narrowed, that statement names 27 tables no matter what else is in the
database, so it can no longer exhaust `max_locks_per_transaction`. The memory
side is largely rather than perfectly fixed — `pg_dump` still reads every
relation from `pg_class` to decide dumpability — but the expensive parts now
scale with `public` alone.

`-n` carries no roles or database-level grants. Neither did the old command;
only `pg_dumpall` emits those.

## Nothing ever deleted a dump

No retention of any kind existed. Ten are kept now, pruned **after** the new
dump is renamed into place — a prune that runs first and then fails to dump has
traded a backup for nothing. Only `firetower-*.dump` and `*.writing` are ever
candidates; it is a bind-mounted directory on somebody's server.

`*.writing` older than a day is swept too. The failure path deletes its own
temporary, and a *killed* `pg_dump` never reaches it — which is exactly what
happened.

## The failure arrived as a wall of text

`Docker::exec` accumulated stderr with no cap, and `LOG_LINES` bounds the
number of lines, not their length. `pg_dump`'s failure is one line, because the
statement it died on names every table.

Capped at 64 KB while reading, keeping the tail. Clipped from the middle when
shown: a Postgres failure puts `ERROR:` at the top and `HINT:` at the bottom,
and truncating from either end loses one of them.

## A killed process was reported as a number

Exit 137 inside a container is almost always the OOM killer, and its stderr is
empty or cut mid-sentence. It now says the dump ran out of memory.

## Nothing counted what it was about to dump

The backup counts the schemas Firetower did not create and says so, pointing at
`docs/updates.md#schemas-firetower-did-not-create`.

**A remark, not a check.** With `-n public` the dump gets through them, so
refusing would block a backup that was going to work. Verified: the shipped
command exits 0 against a database with 233 foreign schemas in it.

## Where those schemas come from

The test suite, pointed at that database. It makes one per test, and
`sweep_test_schemas` is `#[cfg(test)]` — it runs once per test *process* and
does not exist in a release build, so nothing has ever cleaned one up.

How the suite reached a real database is still unknown, and no guard is added
here for it. `deploy/firetower.yml` publishes no port for `postgres`, so
`just test`'s default DSN cannot have reached it from the host; either the
suite ran inside the compose network, or the updater is attached to a compose
project whose `postgres` is the dev one. Writing a guard before knowing which
would be writing the wrong guard.

## Tests

New: the dump is narrowed to `public`; a killed dump says it ran out of memory;
any other failure keeps its code and text; a long failure keeps both ends and
says what it dropped; pruning keeps the newest and drops the rest, oldest
first; pruning touches nothing that is not ours; the remains of a killed dump
are swept once old and a fresh one is not; the new run and step states round
trip through the database; a waiting run is not over; a waiting run is still
active on the screen and reads as wanting attention; a warned step is neither a
tick nor a cross.

343 server, 25 updater, 216 web — all pass. `cargo fmt`, `just check-style`,
`pnpm lint`, `pnpm tsc` clean; no clippy findings in the touched files.

One pre-existing failure untouched by this:
`capacity::a_machine_reports_memory_it_could_actually_have` fails on `main` too
(macOS memory probe).

## Migration

`20260912140000_waiting_decision.sql` rebuilds the partial index behind the
"is anything running" query to include the new state. Neither state column has
a constraint to widen — both are plain `text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEyQPx58L3Tn4uNjcvLgm
